### PR TITLE
Add a code style check to travisCI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,12 +16,10 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false
 BinPackParameters: false
-BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Allman
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit:     80
-CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
@@ -48,14 +46,8 @@ PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Middle
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  true
 SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: true
-SpacesInSquareBrackets: true
 Standard:        Cpp11
 TabWidth:        4
 UseTab:          Never

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,15 @@ language: cpp
 
 sudo: false
 
+# might need to replace above with these commands to allow clang-3.8.
+# sudo: required
+# dist: precise
+
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.8
     packages:
       - ccache
       - libgsl0-dev
@@ -15,6 +20,7 @@ addons:
       - g++-5
       - gfortran-5
       - liblapack-dev
+      - clang-format-3.8
 
 before_install:
  - if [[ ${GVER} ]]; then export CC=gcc-${GVER}; export CXX=g++-${GVER}; export FC=gfortran-${GVER}; fi
@@ -30,18 +36,21 @@ env:
     - CMAKE_VERSION=3.5.2-Linux-x86_64
     - RANDOM123_VER=1.09
     - J=2
+    - OMP_NUM_THREADS=4
+    - CLANG_FORMAT_VER=3.8
   matrix:
     -
+    - STYLE=ON
     - COVERAGE=ON
     - WERROR=ON
 
 script:
     # -Wl,--no-as-needed is a workaround for bugs.debian.org/457284
-  - mkdir build && cd build &&
+  - if [[ ${STYLE} ]]; then regression/check_style.sh -t; else mkdir build && cd build &&
     ${HOME}/cmake-${CMAKE_VERSION}/bin/cmake -DRANDOM123_INCLUDE_DIR=${HOME}/Random123-${RANDOM123_VER}/include -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-as-needed" .. &&
     make -j${J} VERBOSE=1 &&
-    make test ARGS="-E \(c4_tstOMP_2\|viz_tstEnsight_Translator\|cdi_ipcress_tIpcress_Interpreter_Al_BeCu_ipcress\|diagnostics_tDracoInfo\|diagnostics_tDracoInfo_version\|diagnostics_tDracoInfo_brief\|parser_driver4tstConsole_Token_Stream\|c4_tstOMP_1\)" &&
-    make install DESTDIR="${HOME}" && cd -
+    ${HOME}/cmake-${CMAKE_VERSION}/bin/ctest -j ${J} -E \(c4_tstOMP_2\|viz_tstEnsight_Translator\|cdi_ipcress_tIpcress_Interpreter_Al_BeCu_ipcress\|diagnostics_tDracoInfo\|diagnostics_tDracoInfo_version\|diagnostics_tDracoInfo_brief\|parser_driver4tstConsole_Token_Stream\|c4_tstOMP_1\) &&
+    make install DESTDIR="${HOME}" && cd - ; fi
 
 after_success:
   - if [[ ${COVERAGE} ]]; then codecov --gcov-exec gcov-${GVER}; fi

--- a/regression/check_style.sh
+++ b/regression/check_style.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# Run clang-format in the current directory and list locally modified
+# files that are not compliant with the current coding standard (see
+# .clang_format in the top level source directory.)
+
+##---------------------------------------------------------------------------##
+## Environment
+##---------------------------------------------------------------------------##
+
+# Enable job control
+set -m
+
+##---------------------------------------------------------------------------##
+## Support functions
+##---------------------------------------------------------------------------##
+print_use()
+{
+    echo " "
+    echo "Usage: `basename $0` -d -n -t"
+    echo " "
+    echo "All arguments are optional."
+    echo "  -d Diff mode only. Do not modifty files."
+    echo "  -n Alias for -d."
+    echo "  -t Run as a pre-commit check, print list of non-conformant files and return"
+    echo "     with exit code = 1."
+    echo " "
+}
+
+##---------------------------------------------------------------------------##
+## Sanity Checks
+##---------------------------------------------------------------------------##
+
+# clang-format must be in the PATH
+if ! test "${CLANG_FORMAT_VER}x" = "x"; then
+  cfver="-${CLANG_FORMAT_VER}"
+else
+  cfver=""
+fi
+gcf=`which git-clang-format${cfver}`
+cf=`which clang-format${cfver}`
+if test "${gcf}notset" = "notset"; then
+   echo "ERROR: git-clang-format${cfver} was not found in your PATH."
+   echo "pwd="
+   pwd
+   echo "which git-clang-format${cfver}"
+   echo $gcf
+   echo "which clang-format${cfver}"
+   echo $cf
+   echo "which git"
+   which git
+   exit 1
+else
+  echo "Using $gcf --binary $cf"
+fi
+
+ver=`${cf} --version`
+echo " "
+echo "--------------------------------------------------------------------------------"
+echo "Checking modified code for style conformance..."
+echo "  - using clang-format version $ver"
+echo "  - using settings from Draco's .clang_format configuration file."
+echo " "
+
+##---------------------------------------------------------------------------##
+## Default values
+##---------------------------------------------------------------------------##
+pct_mode=0
+diff_mode=0
+allok=0
+
+##---------------------------------------------------------------------------##
+## Command options
+##---------------------------------------------------------------------------##
+
+while getopts ":dhnt" opt; do
+case $opt in
+d) diff_mode=1 ;;
+h) print_use; exit 0 ;;
+n) diff_mode=1 ;;
+t) pct_mode=1 ;;
+\?) echo "" ;echo "invalid option: -$OPTARG"; print_use; exit 1 ;;
+:)  echo "" ;echo "option -$OPTARG requires an argument."; print_use; exit 1 ;;
+esac
+done
+
+##---------------------------------------------------------------------------##
+## Check mode
+##---------------------------------------------------------------------------##
+
+if test "${pct_mode}" = "1"; then
+
+  # don't actually modify the files (compare to branch 'develop')
+  cmd='${gcf} --binary ${cf} -f --diff --extensions hh,cc develop'
+  echo $cmd
+  result=`eval $cmd`
+  allok=`echo $result | grep "did not modify" | wc -l`
+  # 2nd chance (maybe there are no files to check)
+  if test $allok = 0; then
+    allok=`echo $result | grep "no modified files" | wc -l`
+  fi
+
+  if test $allok = 1; then
+    echo "PASS: Changes conform to draco style requirements."
+  else
+    echo "FAIL: some files do not conform to draco style requirements:"
+    echo " "
+    # rerun the command to capture color output.
+    eval $cmd
+    exit 1
+  fi
+
+##---------------------------------------------------------------------------##
+## Fix mode
+##   no options --> fix the files by running clang-format
+##   -d | -n    --> print diff of required changes.
+##---------------------------------------------------------------------------##
+
+else
+
+  if test ${diff_mode} = 1; then
+    cmd='${gcf} --binary ${gf} -f --diff --extensions hh,cc develop'
+    result=`eval $cmd`
+    echo "The following non-conformances were discovered. Rerun without -d|-n to"
+    echo "automatically apply these changes:"
+    echo " "
+    # rerun command to capture color output.
+    eval $cmd
+  else
+    result=`${gcf} --binary ${cf} -f --extensions hh,cc develop`
+    nonconformantfilesfound=`echo $result | grep "changed files" | wc -l`
+    echo "The following files in your working directory were modified to meet the draco"
+    echo "style requirement:"
+    echo " "
+    echo $result
+  fi
+
+fi
+
+##---------------------------------------------------------------------------##
+## End check_style.sh
+##---------------------------------------------------------------------------##


### PR DESCRIPTION
This is WIP...
- Relax some of the checks set by .clang-format.
- Add a new 'style' test to the travisCI matrix.
- The new test uses the provided shell script check_style.sh to ensure new or modified lines of code conform to the style specified by .clang-format.
- Load clang-format-3.8 in the travisCI environment.
- There are several changes recommended by junghans that need to be implemented before this PR is merged. These updates will be added in a separate commit based on the comments that were inadvertantly purged from github when the repo was replaced, but are in a set of emails sent to KT.

To do (comments from junghans)

- [ ] Do you really need sudo and precise? It will make the time until the tests run much longer as travis as more sudo: false containers.
- [x] Is there an advantage of running ctest directly 
  - yes, direct control over `-j`, targets, control parameters, etc.
- [ ] In bash you can use `${0##*/}` instead of `basename $0`.
- [ ] use `if [[ ! ${CLANG_FORMAT_VER} ]]; then` in place of `if ! test "${CLANG_FORMAT_VER}x" = "x"; then`
- [ ] Use `cfver="${CLANG_FORMAT_VER:+-}${CLANG_FORMAT_VER:+-}"` in place of `if ! test "${CLANG_FORMAT_VER}x" = "x"; then ...`
- [ ] Use `grep -c` instead of `grep | wc -l`, saves you a subshell.
- [ ] Use `[[ ! ${gcf} ]]` in place of `if test "${gcf}notset" = "notset"; then`


