### PR TITLE
In the regression system, make github the default location for draco

### DIFF
--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -193,7 +193,7 @@ run "module list"
 
 # Use a unique regression folder for each github branch
 if test ${USE_GITHUB} == 1; then
-  comp=github-$featurebranch-$comp
+  comp=$comp-$featurebranch
 fi
 
 # ----------------------------------------

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -737,16 +737,30 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
     HINTS
     # if DRACO_DIR is defined, use it.
     $ENV{DRACO_DIR}
-    # regress account on ccscs7
-    /home/regress/cmake_draco/${CTEST_MODEL}_${compiler_short_name}/${CTEST_BUILD_CONFIGURATION}/target
     # Try a path parallel to the work_dir
     ${${dep_pkg}_work_dir}/target
     )
 
+  # Second chance
+  if( NOT EXISTS ${${dep_pkg}_target_dir} )
+    # might have a git branch name
+    string( REGEX REPLACE "(Nightly|Experimental)_(.*)/" "\\1_\\2-develop/"
+      ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
+    find_file( ${dep_pkg}_target_dir
+      NAMES README.${dep_pkg}
+      HINTS
+      # if DRACO_DIR is defined, use it.
+      $ENV{DRACO_DIR}
+      # Try a path parallel to the work_dir
+      ${${dep_pkg}_work_dir}/target
+      )
+  endif()
+
   if( NOT EXISTS ${${dep_pkg}_target_dir} )
     message( FATAL_ERROR
       "Could not locate the ${dep_pkg} installation directory. "
-      "${dep_pkg}_target_dir = ${${dep_pkg}_target_dir}" )
+      "${dep_pkg}_target_dir = ${${dep_pkg}_target_dir}"
+      "${dep_pkg}_work_dir   = ${${dep_pkg}_work_dir}")
   endif()
 
   get_filename_component( ${dep_pkg_caps}_DIR ${${dep_pkg}_target_dir} PATH )

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -70,10 +70,13 @@ projects="draco"
 extra_params=""
 regress_mode="off"
 epdash=""
-prdash=""
 userlogdir=""
-featurebranch=""
 export rscriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Default to using GitHub for Draco
+featurebranch=develop # use default branch
+prdash="-"
+USE_GITHUB=1
 
 ##---------------------------------------------------------------------------##
 ## Command options
@@ -317,6 +320,11 @@ if test `echo $projects | grep $subproj | wc -l` -gt 0; then
   sleep 1
   draco_jobid=`jobs -p | sort -gr | head -n 1`
 fi
+
+# Only Draco is on github, other projects still use svn.
+unset featurebranch
+unset prdash
+unset USE_GITHUB
 
 export subproj=jayenne
 if test `echo $projects | grep $subproj | wc -l` -gt 0; then


### PR DESCRIPTION
- For all draco regressions, use github by default. There is no need to specify  '-g' when calling regression-master.sh.  Jayenne and Capsaicin still default to svn.
- Change the directory name for the build directory created by the regression system when source code is checked out from github. The top level directory now uses the following pattern (e.g.: `Nightly_gcc-develop`): `<dashboard_type>_<compiler>-<git branch>`
- Teach the regression system to find the draco installation directory when building Jayenne or Capsaicin. This directory now has '-develop' appended (the git branch name).