### PR TITLE
Updates for releasing draco-6_19_1 on trinitite and trinity.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,27 @@
+2016-06-27  Kelly (KT) Thompson  <kgt@lanl.gov>
+
+	* Release draco-6_19_1. This is patch release.
+
+	* This release was required by Jayenne and Capsaicin.  It is
+	  linked to:
+	  - Jayenne-7_11_1
+	  - Capsaicin-4_8_2
+
+	* Platforms:
+	  TT/TR     Intel 15.0.5    Cray-MPICH2-7.3.3
+
+	* Summary of changes:
+	- 102 files changed, added or removed in 67 commits.
+	- Draco source repository moved to github.com/losalamos/Draco
+	  Many changes to scripts, environments.
+	- Fixed static initialization order bug, #767.
+	- IPO settings consolidated into one place in the build system.
+	- Allow regression scripts to run from developer's checkout.
+	- Update build system to work on CrayPE w/o special config or
+	  cache files.
+	- New fortran interfaces and tests in quadrature.
+	- Begin supporting gcc-6.1.0 on Linux64.
+
 2016-04-28  Kelly (KT) Thompson  <kgt@lanl.gov>
 
 	* Release draco-6_19_0.  This is a minor Draco release.

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -108,7 +108,7 @@ macro(dbsSetupCompilers)
     set( USE_IPO OFF )
   endif()
   set( USE_IPO ${USE_IPO} CACHE BOOL "Use IPO?" FORCE )
-    
+
 endmacro()
 
 #------------------------------------------------------------------------------#
@@ -175,8 +175,6 @@ macro(dbsSetupCxx)
     # libraries if requested with DRACO_LIBRARY_TYPE=STATIC.
     set( CMAKE_EXE_LINKER_FLAGS "-dynamic" CACHE STRING
       "Extra flags for linking executables")
-    set( DRACO_LIBRARY_TYPE "STATIC" CACHE STRING
-      "Keyword for creating new libraries (STATIC or SHARED)." FORCE )
     if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )
       include( unix-intel )
     elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Cray" )
@@ -366,9 +364,7 @@ macro( dbsSetupProfilerTools )
 
   if( USE_ALLINEA_MAP )
     # Ref: www.nersc.gov/users/software/performance-and-debugging-tools/MAP
-    if( "${SITENAME}" STREQUAL "Trinitite" OR
-        "${SITENAME}" STREQUAL "Cielito"   OR
-        "${SITENAME}" STREQUAL "Cielo" )
+    if( CRAY_PE )
       set( platform_cray "--platform=cray")
     endif()
     if( NOT DEFINED ENV{ALLINEA_LICENSE_DIR} AND NOT DEFINED ENV{DDT_LICENSE_FILE} )

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -338,7 +338,7 @@ macro( add_component_library )
   string( REPLACE "_test" "" comp_target ${acl_TARGET} )
   # extract project name, minus leading "Lib_"
   string( REPLACE "Lib_" "" folder_name ${acl_TARGET} )
-  
+
   add_library( ${acl_TARGET} ${DRACO_LIBRARY_TYPE} ${acl_SOURCES} )
   set_target_properties( ${acl_TARGET} PROPERTIES
     # ${compdefs}
@@ -469,9 +469,7 @@ macro( register_scalar_test targetname runcmd command cmd_args )
   # On Cray machines, multiple independent processes cannot share cores on a
   # node.  To prevent ctest from oversubcribing, force numPE and numthreads to
   # be exactly the number of cores per node.
-  if( "${SITENAME}" STREQUAL "Trinitite" OR
-      "${SITENAME}" STREQUAL "Cielito" OR
-      "${SITENAME}" STREQUAL "Cielo" )
+  if( CRAY_PE )
     set( num_procs ${MPI_CORES_PER_CPU} )
   else()
     # For application unit tests, a parallel job is forked that needs more
@@ -621,7 +619,7 @@ macro( register_parallel_test targetname numPE command cmd_args )
     unset( nnodes )
     unset( nnodes_remainder )
 
-  else(addparalleltest_MPI_PLUS_OMP)
+  else()
 
     if( DEFINED addparalleltest_LABEL )
       set_tests_properties( ${targetname}
@@ -639,7 +637,7 @@ macro( register_parallel_test targetname numPE command cmd_args )
         PROPERTIES PROCESSORS "${numPE}" )
     endif()
 
-  endif(addparalleltest_MPI_PLUS_OMP)
+  endif()
 
   # cleanup
   unset( rpt_aprun_depth )

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -38,8 +38,8 @@ function establish_permissions
 function machineName
 {
   sysName=${sysName="unknown"}
-  if test -f /usr/projects/hpcsoft/sys_name; then
-    sysName=`/usr/projects/hpcsoft/sys_name`
+  if test -f /usr/projects/hpcsoft/utilities/bin/sys_name; then
+    sysName=`/usr/projects/hpcsoft/utilities/bin/sys_name`
   elif test -d /projects/darwin; then
     sysName=darwin
   elif test -d /usr/gapps/jayenne; then
@@ -56,8 +56,8 @@ function machineName
 function osName
 {
   osName=${osName="unknown"}
-  if test -f /usr/projects/hpcsoft/sys_os; then
-    osName=`/usr/projects/hpcsoft/sys_os`
+  if test -f /usr/projects/hpcsoft/utilities/bin/sys_os; then
+    osName=`/usr/projects/hpcsoft/utilities/bin/sys_os`
   elif test -d /projects/darwin; then
     osName=darwin
   elif test -d /usr/gapps/jayenne; then
@@ -160,7 +160,7 @@ function selectscratchdir
 {
   # TOSS, CLE, BGQ, Darwin:
   toss2_scratchdirs="net/scratch net/scratch1 net/scratch2 net/scratch3 net/scratch4 scratch6 scratch8 scratch9"
-  cray_scratchdirs="scratch1 lscratch1 lscratch2 lscratch3 lscratch4"
+  cray_scratchdirs="lustre/lscratch2 lustre/lscratch3 lustre/lscratch4 lustre/ttscratch1 lustre/scratch3 lustre/scratch4"
   bgq_scratchdirs="nfs/tmp2"
   scratchdirs="$toss2_scratchdirs $cray_scratchdirs $bgq_scratchdirs \
 usr/projects/draco/devs/releases"
@@ -180,11 +180,10 @@ function lookupppn()
   local ppn=1
   case ${target} in
     c[it]-fe[0-9] | c[it]-login[0-9] | c[it]-vizlogin[0-9]) ppn=16 ;;
-    ty* ) ppn=32 ;;
     mu* ) ppn=24 ;;
     ml* | pi* | wf* | lu* ) ppn=16 ;;
     mp* ) ppn=8 ;;
-    tt-fey* | tt-login*) ppn=32 ;;
+    t[rt]-fey* | t[rt]-login*) ppn=32 ;;
   esac
   echo $ppn
 }
@@ -224,10 +223,10 @@ function npes_test
     np=`cat /proc/cpuinfo | grep processor | wc -l`
   fi
   # For Cray systems limit the test count to 4.
-  local os=`osName`
-  case $os in
-    cle*) np=4 ;;
-  esac
+  # local os=`osName`
+  # case $os in
+  #   cle*) np=4 ;;
+  # esac
   echo $np
 }
 
@@ -326,21 +325,6 @@ function install_versions
   fi
   # source_dir="$source_prefix/source/$package"
   build_dir="$build_prefix/$version/${package:0:1}"
-
-  # Configure options for Cray
-  case `osName` in
-    cle*)
-      if test -f $source_dir/config/CrayConfig.cmake; then
-        CONFIG_EXTRA="-C $source_dir/config/CrayConfig.cmake $CONFIG_EXTRA"
-      elif test -f $draco_dir/cmake/draco/CrayConfig.cmake; then
-        CONFIG_EXTRA="-C $draco_dir/cmake/draco/CrayConfig.cmake $CONFIG_EXTRA"
-      else
-        echo "Could not find CrayConfig.cmake!"
-        exit 1
-      fi
-      # CONFIG_EXTRA="-DDRACO_LIBRARY_TYPE=STATIC $CONFIG_EXTRA"
-      ;;
-  esac
 
   # Purge any existing files before running cmake to configure the build directory.
   if test $config_step == 1; then

--- a/regression/scripts/release_cray.sh
+++ b/regression/scripts/release_cray.sh
@@ -27,11 +27,11 @@
 
 # Draco install directory name (/usr/projects/draco/draco-NN_NN_NN)
 export package=draco
-ddir=draco-6_19_0
+ddir=draco-6_19_1
 pdir=$ddir
 
 # CMake options that will be included in the configuration step
-export CONFIG_BASE="-DDRACO_VERSION_PATCH=0"
+export CONFIG_BASE="-DDRACO_VERSION_PATCH=1"
 
 # environment (use draco modules)
 # release for each module set
@@ -39,22 +39,22 @@ target="`uname -n | sed -e s/[.].*//`"
 case $target in
   c[it]-fe[0-9] | c[it]-login[0-9] | c[it]-vizlogin[0-9])
     environments="intel15env" ;;
-  tt-fey* | tt-login* | tr-fey* | tr-login* )
+  t[rt]-fey* | t[rt]-login* )
     environments="intel15env" ;;
 esac
 function intel15env()
 {
-run "module load friendly-testing user_contrib"
-run "module unload ndi parmetis superlu-dist trilinos"
+run "module load user_contrib friendly-testing"
+run "module unload ndi metis parmetis superlu-dist trilinos"
 run "module unload lapack gsl intel"
 run "module unload cmake numdiff"
 run "module unload intel gcc"
-run "module unload PrgEnv-intel PrgEnv-pgi PrgEnv-cray PrgEnv-gnu"
+run "module unload PrgEnv-intel PrgEnv-cray PrgEnv-gnu"
 run "module unload papi perftools"
 run "module load PrgEnv-intel"
 run "module unload xt-libsci xt-totalview"
 run "module unload intel"
-run "module load gcc/4.8.2 intel/15.0.5.223"
+run "module load intel/15.0.5"
 run "module load gsl/2.1"
 run "module load cmake/3.5.2 numdiff"
 run "module load trilinos/12.6.1 superlu-dist/4.3 metis/5.1.0 parmetis/4.0.3"
@@ -63,7 +63,8 @@ run "module list"
 CC=`which cc`
 CXX=`which CC`
 FC=`which ftn`
-export OMP_NUM_THREADS=8
+export CRAYPE_LINK_TYPE=dynamic
+export OMP_NUM_THREADS=16
 }
 
 # function intel14env()
@@ -117,21 +118,22 @@ ppn=`lookupppn`
 #   be passed to the subshell (bash bug)
 # =============================================================================
 
-OPTIMIZE_ON="-DCMAKE_BUILD_TYPE=Release -DDRACO_LIBRARY_TYPE=STATIC"
-OPTIMIZE_OFF="-DCMAKE_BUILD_TYPE=Debug  -DDRACO_LIBRARY_TYPE=STATIC"
-OPTIMIZE_RWDI="-DCMAKE_BUILD_TYPE=RelWithDebInfo -DDRACO_LIBRARY_TYPE=SHARED"
+OPTIMIZE_ON="-DCMAKE_BUILD_TYPE=Release -DDRACO_LIBRARY_TYPE=SHARED"
+OPTIMIZE_OFF="-DCMAKE_BUILD_TYPE=Debug  -DDRACO_LIBRARY_TYPE=SHARED"
+#OPTIMIZE_RWDI="-DCMAKE_BUILD_TYPE=RelWithDebInfo -DDRACO_LIBRARY_TYPE=SHARED"
 
 LOGGING_ON="-DDRACO_DIAGNOSTICS=7 -DDRACO_TIMING=1"
 LOGGING_OFF="-DDRACO_DIAGNOSTICS=0 -DDRACO_TIMING=0"
 
 # Define the meanings of the various code versions:
 
-VERSIONS=( "debug" "opt" "rwdi" )
+# VERSIONS=( "debug" "opt" "rwdi" )
+VERSIONS=( "debug" "opt" )
 OPTIONS=(\
     "$OPTIMIZE_OFF  $LOGGING_OFF" \
     "$OPTIMIZE_ON   $LOGGING_OFF" \
-    "$OPTIMIZE_RWDI $LOGGING_OFF" \
 )
+#     "$OPTIMIZE_RWDI $LOGGING_OFF" \
 
 ##---------------------------------------------------------------------------##
 ## Environment review


### PR DESCRIPTION
+ Add a brief entry to the ChangLog concerning draco-6_19_1.
+ Switch to using shared libraries instead of static on Cray platforms (compilerEnv.cmake).
+ Update release scripts to point to new files/locations used by HPC to identify the current system (e.g.: /usr/projects/hpcsoft/utilities/bin/sys_name).
+ Add case statements for tt-* and tr-* (trinitite and trinity).
+ No longer use '-C config/CrayConfig.cmake' since cmake/3.5.0+ no longer requires this bootstrapping.
+ Update the list of modulefiles loaded for the release.
+ Replace multiple if statements that match Trinity, Trinitite, etc. with conditional on CRAY_PE.
+ Update list of scratch disk locations.
+ No longer limit ppn on Cray since the test system restricts testing to 1 job per node at any given time.

fixes #13
