### PR TITLE
Added a simple .vimrc file to conform to style guide

### DIFF
--- a/environment/vim/.vimrc
+++ b/environment/vim/.vimrc
@@ -1,0 +1,27 @@
+" vim settings to comply with Draco/Jayenne style guide
+" To include the settings and commands in this file, copy it
+" to your home directory or add this command to your ~/.vimrc file:
+" "source <path_to_draco>/environment/vim/.vimrc"
+
+" Use spaces instead of tabs when indenting with << or >>
+set expandtab
+
+" Be smart when using tabs
+set smarttab
+
+" 1 tab == 4 spaces
+set shiftwidth=4
+set tabstop=4
+
+" function that kills trailing whitespaces
+fun! RemoveTrailing()
+    " save the cursor position
+    let l:save_cursor = getpos('.')
+    " find replace all trailing spaces to end of line
+    %s/\s\+$//e
+    " reset cursor position
+    call setpos('.', l:save_cursor)
+endfun
+
+" fix trailing spaces when you write a file
+autocmd BufWritePre * :call RemoveTrailing()


### PR DESCRIPTION
This .vimrc file sets tabs to spaces, uses the appropriate number of
spaces and automatically removes trailing white spaces when a file is
saved. Users can copy it to their home directory or source it in their
.vimrc file.