### PR TITLE
Fixes to monthly metrics report...

### DIFF
--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -295,6 +295,8 @@ echo "--------------------(end environment)--------------------------"
 echo ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctestparts}
 ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctestparts}
 
+run "cp $COVFILE $COVFILE.bak"
+
 run "chgrp -R draco ${work_dir}"
 run "chmod -R g+rwX,o-rwX ${work_dir}"
 

--- a/regression/mcovdir.cfg
+++ b/regression/mcovdir.cfg
@@ -1,4 +1,4 @@
 -p -q -r
 
-../../draco/source/src/*/
-!../../draco/source/src/*/test/
+../../../scratch/source/src/*/
+!../../../scratch/source/src/*/test/


### PR DESCRIPTION
Recent changes to the regression scripts broke the metrics report. Fixing...

* Update regex in mcovdir.cfg to include/exclude directories for merged coverage report.
* CMake appears to be removing the CMake.cov files automagically now. At least I can't find anything in my scripts that does this at the end of the run. Make a .bak copy of the .cov files.  Update the regression script to use the .bak copies.