### PR TITLE
On Darwin, update draco dev env and regression system to use intel/16

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -187,16 +187,10 @@ endmacro()
 #------------------------------------------------------------------------------
 macro( setupCudaEnv )
 
-  option( USE_CUDA "If CUDA is available, should we use it?" ON )
+  option( USE_CUDA "If CUDA is available, should we use it?" OFF )
   if( USE_CUDA )
 
     message( STATUS "Looking for CUDA..." )
-    # special code for CT/CI (fixed in cmake-3.1.1)
-    # if( "${CMAKE_SYSTEM_PROCESSOR}notset" STREQUAL "notset" AND
-    #     ${CMAKE_SYSTEM_NAME} MATCHES "Catamount")
-    #   set( CMAKE_SYSTEM_PROCESSOR "x86_64" CACHE STRING
-    #     "For unix, this value is set from uname -p." FORCE)
-    # endif()
     find_package( CUDA QUIET )
     set_package_properties( CUDA PROPERTIES
       DESCRIPTION "Toolkit providing tools and libraries needed for GPU applications."

--- a/environment/bashrc/.bashrc_darwin_fe
+++ b/environment/bashrc/.bashrc_darwin_fe
@@ -15,7 +15,7 @@ fi
 # unlimit stack and core dump sizes.
 ulimit -s unlimited
 
-if test "${VENDOR_DIR:-notset}" == "notset"; then
+if [[ ! ${VENDOR_DIR} ]]; then
   export VENDOR_DIR=/usr/projects/draco/vendors
   export PATH=$PATH:$VENDOR_DIR/bin
 fi
@@ -50,17 +50,40 @@ if test -n "$MODULESHOME"; then
     # module load ParMetis/4.0.3 SuperLU_DIST/3.3 trilinos/11.10.2
   else
     module use --append ${VENDOR_DIR}/Modules
-    # setup for draco
-    module load emacs subversion/1.9.3 git
-    module load intel/15.0.4 impi/5.1.1.109 lapack/3.5.0 gsl/2.1
-    module load random123 cmake/3.5.2 numdiff/5.8.1 eospac/6.2.4
-    # additional setup for capsaicin
-    module load ndi metis parmetis superlu-dist trilinos
+    export dracomodules="emacs subversion/1.9.3 git intel/16.0.3 \
+gsl/2.1 random123 cmake/3.6.0 numdiff/5.8.1 \
+eospac/6.2.4 ndi metis parmetis superlu-dist trilinos"
   fi
-  export CXX=`which mpiicpc`
-  export CC=`which mpiicc`
-  export FC=`which mpiifort`
-  export MPIEXEC=`which mpirun`
+
+  function dracoenv ()
+  {
+    for m in $dracomodules; do
+      module load $m
+    done
+    export CXX=`which mpiicpc`
+    export CC=`which mpiicc`
+    export FC=`which mpiifort`
+    export MPIEXEC=`which mpirun`
+    echo "mpd --daemon"
+    mpd --daemon
+  }
+
+  function rmdracoenv ()
+  {
+    unset CXX
+    unset CC
+    unset FC
+    unset MPIEXEC
+    # unload in reverse order.
+    mods=( ${dracomodules} )
+    for ((i=${#mods[@]}-1; i>=0; i--)); do
+      loaded=`echo $LOADEDMODULES | grep -c ${mods[$i]}`
+      if test $loaded = 1; then
+        module unload ${mods[$i]}
+      fi
+    done
+  }
+
 fi
 
 # Avoid printing trigraph chars to the screen (eg: ���)

--- a/regression/darwin-job-launch.sh
+++ b/regression/darwin-job-launch.sh
@@ -85,7 +85,7 @@ for jobid in ${dep_jobids}; do
     done
 done
 
-darwin_regress_script="${regdir}/draco/regression/darwin-regress.msub"
+darwin_regress_script="${rscriptdir}/darwin-regress.msub"
 
 ##---------------------------------------------------------------------------##
 # Proposed: Init, Configure, Build, Test and Submit

--- a/regression/darwin-regress.msub
+++ b/regression/darwin-regress.msub
@@ -47,6 +47,8 @@ export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
 export https_proxy=$http_proxy
 export HTTPS_PROXY=$http_proxy
+export no_proxy=".lanl.gov"
+export NO_PROXY=".lanl.gov"
 export VENDOR_DIR=/usr/projects/draco/vendors
 
 # import some bash functions
@@ -79,9 +81,8 @@ run "module use --append /usr/projects/draco/vendors/Modules"
 # Clear any tcsh loaded modules as these are invalid when staring a new shell.
 run "module purge &> /dev/null"
 run "module load git"
-run "module load intel/15.0.4 impi/5.1.1.109"
-run "module load lapack/3.5.0"
-run "module load cmake/3.5.2 numdiff/5.8.1 subversion random123 eospac/6.2.4"
+run "module load intel/16.0.3"
+run "module load cmake/3.6.0 numdiff/5.8.1 subversion random123 eospac/6.2.4"
 run "module load gsl/2.1 ndi metis parmetis superlu-dist trilinos"
 run "module list"
 
@@ -91,7 +92,7 @@ export CC=`which mpiicc`
 export FC=`which mpiifort`
 export MPIEXEC=`which mpirun`
 # http://stackoverflow.com/questions/11959906/openmp-and-numa-relation
-export OMP_NUM_THREADS=8
+export OMP_NUM_THREADS=`lscpu | grep "per socket" | awk '{print $4}'`
 export OMP_PROC_BIND=true
 comp=`basename $CXX`
 #echo "mpd --daemon"


### PR DESCRIPTION
+ Default `USE_CUDA=OFF,` even if the cuda libraries are found.
+ Change module system to load `intel/16.0.3` by default.  This also brings in Intel MPI 5.1.3 and MKL.
+ Fix the regression system so that it uses the scripts found in the same directory as `regression_master.sh` instead of looking for scripts at `/usr/projects/draco/regress/draco.`

If merged before #34, then #34 will need to be rebased and tested before it can be merged.
