### PR TITLE
Fix a couple of recently discovered issues with the regression system.

### DIFF
--- a/config/vendor_libraries.cmake
+++ b/config/vendor_libraries.cmake
@@ -187,7 +187,9 @@ endmacro()
 #------------------------------------------------------------------------------
 macro( setupCudaEnv )
 
-  option( USE_CUDA "If CUDA is available, should we use it?" OFF )
+  if( NOT DEFINED USE_CUDA )
+    option( USE_CUDA "If CUDA is available, should we use it?" OFF )
+  endif()
   if( USE_CUDA )
 
     message( STATUS "Looking for CUDA..." )

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -182,7 +182,7 @@ esac
 run "module list"
 
 # Use a unique regression folder for each github branch
-if test ${USE_GITHUB} == 1; then
+if test ${USE_GITHUB:-0} == 1; then
   comp=$comp-$featurebranch
 fi
 

--- a/regression/darwin-regress.msub
+++ b/regression/darwin-regress.msub
@@ -116,7 +116,7 @@ esac
 run "module list"
 
 # Use a unique regression folder for each github branch
-if test ${USE_GITHUB} == 1; then
+if test ${USE_GITHUB:-0} == 1; then
   comp=$comp-$featurebranch
 fi
 

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -157,7 +157,7 @@ esac
 run "module list"
 
 # Use a unique regression folder for each github branch
-if test ${USE_GITHUB} == 1; then
+if test ${USE_GITHUB:-0} = 1; then
   comp=$comp-$featurebranch
 fi
 

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -36,7 +36,7 @@ run () {
     if ! test $dry_run; then eval $1; fi
 }
 
-run "module load user_contrib svn"
+run "module load user_contrib svn git"
 
 # Ensure that the permissions are correct
 run "umask 0002"

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -136,7 +136,7 @@ run "module unload xt-totalview xt-libsci "
 run "module list"
 
 # Use a unique regression folder for each github branch
-if test ${USE_GITHUB} == 1; then
+if test ${USE_GITHUB:-0} = 1; then
   comp=$comp-$featurebranch
 fi
 


### PR DESCRIPTION
+ Recent changes uncovered a couple of older issues in the regression system.
+ Because `USE_CUDA` now defaults to `OFF`, we need an extra check in `setupCuda` to turn it on in Jayenne if it is turned on in the version of Draco that we are linking to.
+ Fix a problem that could occur if `USE_GITHUB` was never set.
+ Load a newer version of git before trying to rebase from within the nightly regression system.