### PR TITLE
Update development environment for Trinitite with Redwood UP01.

### DIFF
--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -42,18 +42,18 @@ module load user_contrib friendly-testing
 #module use --append ~/modulefiles/trinitite
 
 export dracomodules="metis parmetis/4.0.3 trilinos/12.6.1 superlu-dist/4.3 \
-gsl/2.1 cmake/3.5.2 numdiff ndi random123 eospac/6.2.4 \
-subversion"
+gsl/2.1 cmake/3.6.1 numdiff ndi random123 eospac/6.2.4 \
+subversion git"
 
 function dracoenv ()
 {
   #module unload PrgEnv-intel PrgEnv-cray PrgEnv-gnu
   #module load PrgEnv-intel
-  module swap intel intel/15.0.5
+  #module swap intel intel/16.0.3
+  module unload gcc/6.1.0 cray-libsci
   for m in $dracomodules; do
     module load $m
   done
-  module unload xt-libsci
   export CXX=CC
   export CC=cc
   export FC=ftn
@@ -65,14 +65,15 @@ function rmdracoenv ()
   # unload in reverse order.
   mods=( ${dracomodules} )
   for ((i=${#mods[@]}-1; i>=0; i--)); do
-    loaded=`echo $LOADEDMODULES | grep -c ${mods[$i]}`
-    if test $loaded = 1; then
+    # loaded=`echo $LOADEDMODULES | grep -c ${mods[$i]}`
+    #if test $loaded = 1; then
       module unload ${mods[$i]}
-    fi
+    #fi
   done
-  module unload intel
+  # module unload intel
   # module unload gcc
-  # module unload PrgEnv-intel
+  module unload PrgEnv-intel
+  module load PrgEnv-intel
   # module load PrgEnv-pgi
 }
 

--- a/environment/cshrc/.cshrc
+++ b/environment/cshrc/.cshrc
@@ -73,39 +73,6 @@ case redcap*:
     module load git svn
     breaksw
 
-case ct*:
-case ci*:
-    setenv VENDOR_DIR /usr/projects/draco/vendors
-    # source /usr/projects/crestone/dotfiles/Cshrc
-    module load user_contrib friendly-testing
-
-    # Move some environment out of the way.
-    module unload PrgEnv-intel PrgEnv-pgi
-    module unload cmake numdiff svn gsl
-    module unload papi perftools
-
-    # load the Intel programming env, but then unloda libsci and totalview
-    module load PrgEnv-intel # this loads xt-libsci and intel/XXX
-    module unload xt-libsci intel # xt-totalview
-    module load intel/15.0.5.223
-
-    # draco modules start here.
-    module load metis parmetis/4.0.3 trilinos/12.6.1 superlu-dist/4.3
-    module load gsl/2.1 cmake/3.5.2 numdiff ndi random123 eospac/6.2.4 emacs
-    module load subversion git gcc
-
-    setenv OMP_NUM_THREADS 8
-    setenv CXX CC
-    setenv CC cc
-    setenv FC ftn
-    setenv CRAYPE_LINK_TYPE dynamic
-
-    # Avoid run time messages of the form:
-    # "OMP: Warning #72: KMP_AFFINITY: affinity only supported for Intel(R) processors."
-    # Ref: http://software.intel.com/en-us/articles/bogus-openmp-kmp_affinity-warnings-on-non-intel-processor-hosts/
-    setenv KMP_AFFINITY none
-    breaksw
-
 case tt*:
 case tr*:
 
@@ -120,13 +87,12 @@ case tr*:
 
     # load the Intel programming env, but then unloda libsci and totalview
     module load PrgEnv-intel # this loads xt-libsci and intel/XXX
-    module unload xt-libsci intel # xt-totalview
-    module load intel/15.0.5
+    module unload cray-libsci gcc/6.1.0
 
     # draco modules start here.
     module load metis parmetis/4.0.3 trilinos/12.6.1 superlu-dist/4.3
-    module load gsl/2.1 cmake/3.5.2 numdiff ndi random123 eospac/6.2.4
-    module load subversion
+    module load gsl/2.1 cmake/3.6.1 numdiff ndi random123 eospac/6.2.4
+    module load subversion git
 
     setenv OMP_NUM_THREADS 16
     setenv CXX CC

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -105,13 +105,10 @@ run "module unload superlu-dist metis parmetis"
 run "module unload PrgEnv-intel PrgEnv-pgi PrgEnv-cray"
 # Load new environment
 run "module load PrgEnv-intel"
-run "module unload xt-libsci xt-totalview"
-run "module unload intel"
-run "module load intel/15.0.5"
-run "module load cmake/3.5.2 numdiff subversion"
-run "module load gsl/2.1  random123 eospac/6.2.4 ndi"
+run "module unload cray-libsci gcc/6.1.0"
+run "module load cmake/3.6.1 numdiff subversion git"
+run "module load gsl/2.1 random123 eospac/6.2.4 ndi"
 run "module load trilinos/12.6.1 ndi metis parmetis/4.0.3 superlu-dist/4.3"
-run "module load git"
 
 export CC=`which cc`
 export CXX=`which CC`


### PR DESCRIPTION
+ Begin using cmake/3.6.1 (was 3.5.2)
+ Load the git module.
+ The new default compiler is intel/16.0.3 (but unload gcc/6.1.0 that is automatically loaded with PrgEnv-intel).
+ Retire CI/CT case from .cshrc
+ I cannot compile capsaicin yet. I may need to rebuild trilinos.
+ Regressions are only working for draco.