### PR TITLE
Regression updates for improved support of trinitite (knl vs. haswell)

### DIFF
--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -740,14 +740,14 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
     string( REPLACE "intel-perfbench" "icpc"   ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
   endif()
 
-  find_file( ${dep_pkg}_target_dir
-    NAMES README.${dep_pkg}
-    HINTS
-    # if DRACO_DIR is defined, use it.
-    $ENV{DRACO_DIR}
-    # Try a path parallel to the work_dir
-    ${${dep_pkg}_work_dir}/target
-    )
+  # find_file( ${dep_pkg}_target_dir
+  #   NAMES README.${dep_pkg}
+  #   HINTS
+  #   # if DRACO_DIR is defined, use it.
+  #   $ENV{DRACO_DIR}
+  #   # Try a path parallel to the work_dir
+  #   ${${dep_pkg}_work_dir}/target
+  #   )
 
   # Second chance
   if( NOT EXISTS ${${dep_pkg}_target_dir} )

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -38,10 +38,10 @@ print_use()
     echo "   -d    dashboard type = { Experimental, Nightly }"
     echo "   -f    git feature branch, default=develop"
     echo "         common: 'pr42'"
-    echo "   -p    project names  = { draco, jayenne, capsaicin, asterisk }"
+    echo "   -p    project names  = { draco, jayenne, capsaicin }"
     echo "                          This is a space delimited list within double quotes."
     echo "   -e    extra params   = { none, clang, coverage, cuda, fulldiagnostics,"
-    echo "                            gcc530, gcc610, nr, perfbench, pgi}"
+    echo "                            knl, gcc530, gcc610, nr, perfbench, pgi}"
     echo " "
     echo "Example:"
     echo "./regression-master.sh -b Release -d Nightly -p \"draco jayenne capsaicin\""
@@ -119,7 +119,7 @@ esac
 
 for proj in ${projects}; do
    case $proj in
-   draco | jayenne | capsaicin | asterisk) # known projects, continue
+   draco | jayenne | capsaicin) # known projects, continue
       ;;
    *)  echo "" ;echo "FATAL ERROR: unknown project name (-p) = ${proj}"
        print_use; exit 1 ;;
@@ -131,9 +131,9 @@ if [[ ${extra_params} ]]; then
    none)
       # if 'none' set to blank
       extra_params=""; epdash="" ;;
-   coverage | cuda | fulldiagnostics | nr | perfbench | pgi )
+   bounds_checking | clang | coverage | cuda | fulldiagnostics | knl | gcc530 )
       ;;
-   bounds_checking | gcc530 | clang | gcc610 )
+   gcc610 | nr | perfbench | pgi )
       ;;
    *)  echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
        print_use; exit 1 ;;
@@ -186,7 +186,7 @@ tt-*)
     if [[ ${extra_params} ]]; then
         case $extra_params in
         none) extra_params=""; epdash="" ;;
-        fulldiagnostics | nr | perfbench ) # known, continue
+        fulldiagnostics | knl | nr | perfbench ) # known, continue
         ;;
         *)  echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
             print_use; exit 1 ;;

--- a/regression/tt-crontab
+++ b/regression/tt-crontab
@@ -1,8 +1,18 @@
 # crontab for tt-fey
 
+# --------------------
+# Haswell
+# --------------------
+
 01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/tt-Debug-master.log
 
 01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/tt-Release-master.log
+
+# --------------------
+# KNL
+# --------------------
+
+# 01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco" -e knl &> /usr/projects/jayenne/regress/logs/tt-Debug-knl-master.log
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/tt-job-launch.sh
+++ b/regression/tt-job-launch.sh
@@ -84,6 +84,13 @@ for jobid in ${dep_jobids}; do
     done
 done
 
+# Select haswell or knl partition
+# option '-e knl' will select KNL, default is haswell.
+case $extra_params in
+knl) partition_options="-lnodes=8:knl:ppn=68,walltime=8:00:00" ;;
+*)   partition_options="-lnodes=8:haswell:ppn=32,walltime=8:00:00" ;;
+esac
+
 # Configure, Build on front end
 export REGRESSION_PHASE=cb
 echo "Configure and Build on the front end..."
@@ -98,7 +105,7 @@ echo " "
 export REGRESSION_PHASE=t
 echo "Test from the login node..."
 echo " "
-cmd="/opt/MOAB/bin/msub -j oe -V -o ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-${REGRESSION_PHASE}.log ${rscriptdir}/tt-regress.msub"
+cmd="/opt/MOAB/bin/msub -j oe -V -o ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-${REGRESSION_PHASE}.log ${partition_options} ${rscriptdir}/tt-regress.msub"
 echo "${cmd}"
 jobid=`eval ${cmd}`
 jobid=`echo $jobid | sed '/^$/d'`

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -1,8 +1,5 @@
 #!/bin/bash -l
 
-#MSUB -l walltime=08:00:00
-#MSUB -l nodes=8:ppn=32
-
 ##---------------------------------------------------------------------------##
 ## File  : regression/tt-regress.msub
 ## Date  : Tuesday, May 31, 2016, 14:48 pm
@@ -56,6 +53,10 @@ machine=`uname -n`
 case $machine in
 tt-login[0-9]*)
     ctestparts="Test"
+
+    # Node type (aprun -n 1 lscpu)
+    partition=`aprun -q -n $PBS_NUM_NODES -N 1 grep -i "model name" /proc/cpuinfo | sort | uniq -c`
+
     # Force create of a new log file (don't append)
     echo "Purging ${logdir}/tt-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-t.log"
     echo "    " > ${logdir}/tt-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-t.log
@@ -81,6 +82,12 @@ echo "==========================================================================
 echo "Trinitite regression: ${ctestparts} from ${machine}."
 echo "                      ${subproj}-${build_type}${epdash}${extra_params}${featurebranch}"
 echo "==========================================================================="
+if [[ ${partition} ]]; then
+  echo " "
+  echo "Allocation configuration:"
+  echo $partition
+  echo " "
+fi
 
 # Modules
 # ----------------------------------------
@@ -91,7 +98,7 @@ else
     echo 'module function does not exist. defining a local function ...'
     module ()
     {
-        eval `/opt/modules/3.2.6.7/bin/modulecmd bash $*`
+        eval `/opt/cray/pe/modules/3.2.10.4/bin/modulecmd bash $*`
     }
 fi
 
@@ -114,11 +121,15 @@ export CC=`which cc`
 export CXX=`which CC`
 export FC=`which ftn`
 export CRAYPE_LINK_TYPE=dynamic
+    export OMP_NUM_THREADS=16
 comp=CC
-export OMP_NUM_THREADS=16
 
 # Extra parameers
 case $extra_params in
+knl)
+    run "module swap craype-haswell craype-mic-knl"
+    export OMP_NUM_THREADS=17
+    ;;
 "")
     # revert to intel/14 as the default setup.
     ;;
@@ -129,11 +140,10 @@ case $extra_params in
     exit 1
     ;;
 esac
-run "module unload xt-totalview xt-libsci "
 run "module list"
 
 # Use a unique regression folder for each github branch
-if test ${USE_GITHUB:-0} = 1; then
+if test ${USE_GITHUB:-0} == 1; then
   comp=$comp-$featurebranch
 fi
 


### PR DESCRIPTION
* Begin adding options to support knl-based regressions:
  * Regression master will now accept '`-e knl`'
  * Provide a sample crontab for knl-based regression on trinitite.
  * For trinitite, move the moab allocation parameters from `tt-regress.msub` to command line arguments in `tt-job-launch.sh`. This allows the regression system to swap between `-lnodes=8:knl:ppn=68` and `-lnodes=8:haswell:ppn=32`. The addition of 'knl' or 'haswell' ensures that the allocation doesn't mix knl and haswells in the granted allocation.
  * Add a partition report to the "t" logfile. For example (512 haswell cores)
```
      Allocation configuration:
      512 model name : Intel(R) Xeon(R) CPU E5-2698 v3 @ 2.30GHz
```
* When the regression system is looking for a Draco install from a previous regression run (i.e. Jayenne needs the current draco libraries), only accept directories that inlcude '-develop' to ensure that we don't link to orphaned build directories left over from pre-github based regressions.
* Remove some scripting related to the asterisk project.