### PR TITLE
Updates to the regression and script system to support Jayenne at gitlab

### DIFF
--- a/environment/bin/bash_functions.sh
+++ b/environment/bin/bash_functions.sh
@@ -250,6 +250,7 @@ function rm_from_path ()
 
 ##---------------------------------------------------------------------------##
 ## Toggle LANL proxies on/off
+## https://wiki.archlinux.org/index.php/proxy_settings
 ##---------------------------------------------------------------------------##
 function proxy()
 {
@@ -259,8 +260,8 @@ function proxy()
     export https_proxy=$http_proxy
     export HTTP_PROXY=$http_proxy
     export HTTPS_PROXY=$http_proxy
-    export http_no_proxy="*.lanl.gov"
-    export no_proxy=lanl.gov
+    # export http_no_proxy="*.lanl.gov"
+    export no_proxy="localhost,127.0.0.1,.lanl.gov"
     export NO_PROXY=$no_proxy
   else
     # proxies are set, kill them
@@ -268,7 +269,7 @@ function proxy()
     unset https_proxy
     unset HTTP_PROXY
     unset HTTPS_PROXY
-    unset http_no_proxy
+    #unset http_no_proxy
     unset no_proxy
     unset NO_PROXY
   fi

--- a/regression/Draco_Linux64.cmake
+++ b/regression/Draco_Linux64.cmake
@@ -95,6 +95,7 @@ if( ${CTEST_CONFIGURE} )
 
    message( "setup_for_code_coverage()" )
    setup_for_code_coverage() # from draco_regression_macros.cmake
+
    message(  "ctest_configure()" )
    ctest_configure(
       BUILD        "${CTEST_BINARY_DIRECTORY}"
@@ -125,9 +126,9 @@ if( ${CTEST_BUILD} )
 
    message( "ctest_build(
    TARGET install
+   RETURN_VALUE res
    NUMBER_ERRORS num_errors
-   NUMBER_WARNINGS num_warnings
-   RETURN_VALUE res )" )
+   NUMBER_WARNINGS num_warnings )" )
    ctest_build(
       TARGET install
       RETURN_VALUE res

--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -10,10 +10,26 @@
 00 01 * * 0-6 /scratch/regress/draco/regression/push_repositories_xf.sh &> /home/kellyt/logs/push_repositories_xf.log
 
 # Keep a local bare copy of the repo available on the ccs-net.  This is used by Redmine.
+# Befor this will work, the target directory must be created:
+# cd /ccs/codes/radtran/git
+# git clone --bare git@github.com:losalamos/Draco.git Draco.git
+# git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne.git
 */15 * * * * cd /ccs/codes/radtran/git/Draco.git && git fetch origin +refs/heads/*:refs/heads/* && git reset --soft
+*/15 * * * * cd /ccs/codes/radtran/git/jayenne.git && git fetch origin +refs/heads/*:refs/heads/* && git reset --soft
 
 #------------------------------------------------------------------------------#
 # Regressions with system default compiler (gcc-4.8.5)
+# -a build autodoc
+# -r use regress account
+# -b build_type: Release|Debug
+# -d dashboard:  Nightly|Experimental
+# -p projects:
+# -e extra args:
+#    coverage        - build bullseyecoverage data and send it to cdash
+#    bounds-checking - turn on bounds checking in the STL
+#    clang
+#    gcc530
+#    gcc610
 #------------------------------------------------------------------------------#
 05 00 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -a -r -b Release -d Nightly -p "draco jayenne capsaicin" &> /scratch/regress/logs/ccscs-Release-master.log
 
@@ -32,12 +48,14 @@
 00 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc610 &> /scratch/regress/logs/ccscs-Debug-gcc610-master.log
 
 #------------------------------------------------------------------------------#
-# Github and PRs
+# Special build for a Pull Request that is under consideration
 #------------------------------------------------------------------------------#
 
-# 00 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -g -b Release -d Nightly -p "draco" &> /scratch/regress/logs/ccscs-Release-master-github.log
+# Build both draco and jayenne from PRs.
+# 05 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Experimental -p "draco jayenne" -f "develop pr42" &> /scratch/regress/logs/ccscs-Release-master-pr1.log
 
-# 05 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -g -b Release -d Experimental -p "draco" -f pr1 &> /scratch/regress/logs/ccscs-Release-master-pr1.log
+# Build jayenne from PR (use develop for draco)
+# 05 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Experimental -p "draco" -f "pr42" &> /scratch/regress/logs/ccscs-Release-master-pr1.log
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -7,15 +7,10 @@
 01 22 * * 0-6 /scratch/regress/draco/regression/update_regression_scripts.sh &> /scratch/regress/logs/update_regression_scripts.log
 
 # Send a copy of our repositories to the Red.
-00 01 * * 0-6 /scratch/regress/draco/regression/push_repositories_xf.sh &> /home/kellyt/logs/push_repositories_xf.log
+00 01 * * 0-6 /scratch/regress/draco/regression/push_repositories_xf.sh &> /scratch/regress/logs/push_repositories_xf.log
 
 # Keep a local bare copy of the repo available on the ccs-net.  This is used by Redmine.
-# Befor this will work, the target directory must be created:
-# cd /ccs/codes/radtran/git
-# git clone --bare git@github.com:losalamos/Draco.git Draco.git
-# git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne.git
-*/15 * * * * cd /ccs/codes/radtran/git/Draco.git && git fetch origin +refs/heads/*:refs/heads/* && git reset --soft
-*/15 * * * * cd /ccs/codes/radtran/git/jayenne.git && git fetch origin +refs/heads/*:refs/heads/* && git reset --soft
+*/15 * * * * /scratch/regress/draco/regression/sync_repository.sh &> /scratch/regress/logs/sync_repository.log
 
 #------------------------------------------------------------------------------#
 # Regressions with system default compiler (gcc-4.8.5)

--- a/regression/ccscs-job-launch.sh
+++ b/regression/ccscs-job-launch.sh
@@ -31,23 +31,41 @@ done
 # sanity check
 if [[ ! ${regdir} ]]; then
     echo "FATAL ERROR in ${scriptname}: You did not set 'regdir' in the environment!"
+    echo "printenv -> "
+    printenv
     exit 1
 fi
 if [[ ! ${rscriptdir} ]]; then
     echo "FATAL ERROR in ${scriptname}: You did not set 'rscriptdir' in the environment!"
+    echo "printenv -> "
+    printenv
     exit 1
 fi
 if [[ ! ${subproj} ]]; then
     echo "FATAL ERROR in ${scriptname}: You did not set 'subproj' in the environment!"
+    echo "printenv -> "
+    printenv
     exit 1
 fi
 if [[ ! ${build_type} ]]; then
     echo "FATAL ERROR in ${scriptname}: You did not set 'build_type' in the environment!"
+    echo "printenv -> "
+    printenv
     exit 1
 fi
 if [[ ! ${logdir} ]]; then
     echo "FATAL ERROR in ${scriptname}: You did not set 'logdir' in the environment!"
+    echo "printenv -> "
+    printenv
     exit 1
+fi
+
+if test $subproj == draco || test $subproj == jayenne; then
+  if [[ ! ${featurebranch} ]]; then
+    echo "FATAL ERROR in ${scriptname}: You did not set 'featurebranch' in the environment!"
+    echo "printenv -> "
+    printenv
+  fi
 fi
 
 # Banner
@@ -62,6 +80,9 @@ if [[ ! ${extra_params} ]]; then
   echo "   extra_params   = none"
 else
   echo "   extra_params   = ${extra_params}"
+fi
+if [[ ${featurebranch} ]]; then
+  echo "   featurebranch  = ${featurebranch}"
 fi
 echo "   regdir         = ${regdir}"
 echo "   rscriptdir     = ${rscriptdir}"

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -43,7 +43,13 @@ export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
 export https_proxy=$http_proxy
 export HTTPS_PROXY=$http_proxy
+# ctest submit seems to ignore these no proxy settings, so we must unset the
+# above proxy env variables before submitting the results to cdash.
+export no_proxy="localhost,127.0.0.1,rtt.lanl.gov,.lanl.gov"
+export NO_PROXY=$no_proxy
 export VENDOR_DIR=/scratch/vendors
+# gitlab.lanl.gov has an unkown certificate, disable checking
+export GIT_SSL_NO_VERIFY=true
 
 # import some bash functions
 source $rscriptdir/scripts/common.sh
@@ -295,7 +301,9 @@ echo "--------------------(end environment)--------------------------"
 echo ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctestparts}
 ctest -VV -S ${script_dir}/${script_name},${dashboard_type},${build_type},${ctestparts}
 
-run "cp $COVFILE $COVFILE.bak"
+if test -f $COVFILE; then
+  run "cp $COVFILE $COVFILE.bak"
+fi
 
 run "chgrp -R draco ${work_dir}"
 run "chmod -R g+rwX,o-rwX ${work_dir}"

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -33,7 +33,7 @@ macro( find_num_procs_avail_for_running_tests )
   elseif( NOT "$ENV{SLURM_NPROCS}x" STREQUAL "x")
     set( num_test_procs $ENV{SLURM_NPROCS} )
   else()
-    # If this is not a known batch system, the attempt to set values according
+    # If this is not a known batch system, then attempt to set values according
     # to machine name:
     include(ProcessorCount)
     ProcessorCount(num_test_procs)
@@ -741,8 +741,12 @@ endmacro(process_cc_or_da)
 macro(set_pkg_work_dir this_pkg dep_pkg)
 
   string( TOUPPER ${dep_pkg} dep_pkg_caps )
-  # Assume that draco_work_dir is parallel to our current location.
-  string( REPLACE ${this_pkg} ${dep_pkg} ${dep_pkg}_work_dir $ENV{work_dir} )
+  # Assume that draco_work_dir is parallel to our current location, but
+  # only replace the directory name preceeding the dashboard name.
+  message("ENV{work_dir} = $ENV{work_dir}")
+  string( REGEX REPLACE "${this_pkg}/(Nightly|Experimental|Continuous)" "${dep_pkg}/\\1"
+    ${dep_pkg}_work_dir $ENV{work_dir} )
+  message("${dep_pkg}_work_dir = ${${dep_pkg}_work_dir}")
 
   # If this is a coverage/nr build, link to the Debug/Release Draco files:
   if( "${dep_pkg}" MATCHES "draco" )
@@ -756,13 +760,13 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
     if( "${this_pkg}" MATCHES "jayenne" )
       # If this is jayenne, we might be building a pull request. Replace the PR
       # number in the path with '-develop' before looking for draco.
-      string( REGEX REPLACE "(Nightly|Experimental)_(.*)(-pr[0-9]+)/" "\\1_\\2-develop/"
+      string( REGEX REPLACE "(Nightly|Experimental|Continuous)_(.*)(-pr[0-9]+)/" "\\1_\\2-develop/"
         ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     endif()
 
     if( "${this_pkg}" MATCHES "capsaicin" )
       # Probably building capsaicin, append '-develop' when looking for draco.
-      string( REGEX REPLACE "(Nightly|Experimental)_(.*)/" "\\1_\\2-develop/"
+      string( REGEX REPLACE "(Nightly|Experimental|Continuous)_(.*)/" "\\1_\\2-develop/"
         ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     endif()
   endif()

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -743,7 +743,6 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
   string( TOUPPER ${dep_pkg} dep_pkg_caps )
   # Assume that draco_work_dir is parallel to our current location.
   string( REPLACE ${this_pkg} ${dep_pkg} ${dep_pkg}_work_dir $ENV{work_dir} )
-  message("${dep_pkg}_work_dir = ${${dep_pkg}_work_dir}")
 
   # If this is a coverage/nr build, link to the Debug/Release Draco files:
   if( "${dep_pkg}" MATCHES "draco" )
@@ -768,14 +767,14 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
     endif()
   endif()
 
-  # find_file( ${dep_pkg}_target_dir
-  #   NAMES README.${dep_pkg}
-  #   HINTS
-  #   # if DRACO_DIR is defined, use it.
-  #   $ENV{DRACO_DIR}
-  #   # Try a path parallel to the work_dir
-  #   ${${dep_pkg}_work_dir}/target
-  #   )
+  find_file( ${dep_pkg}_target_dir
+    NAMES README.${dep_pkg}
+    HINTS
+    # if DRACO_DIR is defined, use it.
+    $ENV{DRACO_DIR}
+    # Try a path parallel to the work_dir
+    ${${dep_pkg}_work_dir}/target
+  )
 
   if( NOT EXISTS ${${dep_pkg}_target_dir} )
     message( FATAL_ERROR

--- a/regression/fetch_co.sh
+++ b/regression/fetch_co.sh
@@ -2,21 +2,35 @@
 
 # fetch and checkout
 # $1 is the path to git
-# $2 is the pull request number (e.g.: 42)
+# $2 is the host ('github' or 'gitlab')
+# $3 is the pull request number (e.g.: 42)
 
 GIT=$1
-featurebranch=$2
+githost=$2
+featurebranch=$3
 
 if ! test -x $GIT; then
    echo "FATAL ERROR: unable to run GIT=$GIT."
    exit 1
 fi
-if test "${featurebranch}x" == "x"; then
-   echo "FATAL ERROR: exected two arguments: fetch_co.sh <path to git> <42>"
+if [[ ! ${githost} ]]; then
+   echo "FATAL ERROR: exected three arguments, example: fetch_co.sh <path to git> <github> <42>"
+   echo "     second argument should be 'github' or 'gitlab'"
+   exit 1
+fi
+if [[ ! ${featurebranch} ]]; then
+   echo "FATAL ERROR: exected three arguments, example: fetch_co.sh <path to git> <github> <42>"
+   echo "     third argument should be a bare integer (the pull request number)."
    exit 1
 fi
 
-cmd="${GIT} fetch origin pull/${featurebranch}/head:pr${featurebranch}"
+if test $githost = "github"; then
+  prdir="pull"
+else
+  prdir="merge-requests"
+fi
+
+cmd="${GIT} fetch origin ${prdir}/${featurebranch}/head:pr${featurebranch}"
 echo $cmd
 eval $cmd
 

--- a/regression/ml-crontab
+++ b/regression/ml-crontab
@@ -4,6 +4,16 @@
 
 #------------------------------------------------------------------------------#
 # CUDA (Intel/15.0.5 and OpenMPI/1.6.5)
+# -a build autodoc
+# -r use regress account
+# -b build_type: Release|Debug
+# -d dashboard:  Nightly|Experimental
+# -p projects:
+# -e extra args:
+#    cuda  - build portions of the code that work with CUDA
+#    pgi   - build with the PGI compiler
+#    nr    - build with non-reproducible option.
+#    fulldiagnostics - build with IEEE checks enabled
 #------------------------------------------------------------------------------#
 
 01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e cuda -p "draco jayenne" &> /usr/projects/jayenne/regress/logs/ml-Debug-cuda-master.log

--- a/regression/ml-job-launch.sh
+++ b/regression/ml-job-launch.sh
@@ -59,6 +59,14 @@ if [[ ! ${logdir} ]]; then
     exit 1
 fi
 
+if test $subproj == draco || test $subproj == jayenne; then
+  if [[ ! ${featurebranch} ]]; then
+    echo "FATAL ERROR in ${scriptname}: You did not set 'featurebranch' in the environment!"
+    echo "printenv -> "
+    printenv
+  fi
+fi
+
 # What queue should we use
 #access_queue=""
 #if test -x /opt/MOAB/bin/drmgroups; then
@@ -82,6 +90,9 @@ if [[ ! ${extra_params} ]]; then
 else
   echo "   extra_params   = ${extra_params}"
 fi
+if [[ ${featurebranch} ]]; then
+  echo "   featurebranch  = ${featurebranch}"
+fi
 echo "   regdir         = ${regdir}"
 echo "   rscriptdir     = ${rscriptdir}"
 echo "   logdir         = ${logdir}"
@@ -104,6 +115,13 @@ for jobid in ${dep_jobids}; do
        sleep 5m
     done
 done
+
+if ! test -d $logdir; then
+  mkdir -p $logdir
+  chgrp draco $logdir
+  chmod g+rwX $logdir
+  chmod g+s $logdir
+fi
 
 # Configure on the front end
 echo "Configure:"

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -46,8 +46,13 @@ export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
 export https_proxy=$http_proxy
 export HTTPS_PROXY=$http_proxy
-export VENDOR_DIR=/usr/projects/draco/vendors
-machine=`uname -n`
+# ctest submit seems to ignore these no proxy settings, so we must unset the
+# above proxy env variables before submitting the results to cdash.
+export no_proxy="localhost,127.0.0.1,rtt.lanl.gov,.lanl.gov"
+export NO_PROXY=$no_proxy
+export VENDOR_DIR=/scratch/vendors
+# gitlab.lanl.gov has an unkown certificate, disable checking
+export GIT_SSL_NO_VERIFY=true
 
 # import some bash functions
 source $rscriptdir/scripts/common.sh
@@ -65,6 +70,9 @@ s)
     ;;
 esac
 
+# Header
+# ----------------------------------------
+machine=`uname -n`
 echo "==========================================================================="
 echo "Moonlight regression: ${ctestparts} from ${machine}."
 echo "                      ${subproj}-${build_type}${epdash}${extra_params}${featurebranch}"
@@ -157,7 +165,7 @@ esac
 run "module list"
 
 # Use a unique regression folder for each github branch
-if test ${USE_GITHUB:-0} = 1; then
+if test ${USE_GITHUB:-0} == 1; then
   comp=$comp-$featurebranch
 fi
 
@@ -176,7 +184,7 @@ fi
 # Build type     : Release, Debug
 
 if [[ ! ${dashboard_type} ]]; then
-   dashboard_type=Experimental
+   dashboard_type=Nightly
 fi
 if [[ ! ${base_dir} ]]; then
    # Keep build and target dirs out of /usr/projects locations to

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -321,12 +321,11 @@ if test `echo $projects | grep -c $subproj` -gt 0; then
   eval "${cmd} &"
   sleep 1
   draco_jobid=`jobs -p | sort -gr | head -n 1`
+  ((ifb++))
 fi
-
 
 export subproj=jayenne
 if test `echo $projects | grep -c $subproj` -gt 0; then
-  ((ifb++))
   export featurebranch=${fb[$ifb]}
   # Run the *-job-launch.sh script (special for each platform).
   cmd="${rscriptdir}/${machine_name_short}-job-launch.sh"
@@ -339,6 +338,7 @@ if test `echo $projects | grep -c $subproj` -gt 0; then
   eval "${cmd} &"
   sleep 1
   jayenne_jobid=`jobs -p | sort -gr | head -n 1`
+  ((ifb++))
 fi
 
 # Only Draco is on github, other projects still use svn.
@@ -350,7 +350,6 @@ unset USE_GITHUB
 
 export subproj=capsaicin
 if test `echo $projects | grep -c $subproj` -gt 0; then
-  # ((ifb++))
   cmd="${rscriptdir}/${machine_name_short}-job-launch.sh"
   # Wait for draco regressions to finish
   case $extra_params in

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -42,7 +42,7 @@ print_use()
     echo "   -p    project names  = { draco, jayenne, capsaicin }"
     echo "                          This is a space delimited list within double quotes."
     echo "   -e    extra params   = { none, clang, coverage, cuda, fulldiagnostics,"
-    echo "                            gcc530, gcc610, nr, perfbench, pgi}"
+    echo "                            knl, gcc530, gcc610, nr, perfbench, pgi}"
     echo " "
     echo "Example:"
     echo "./regression-master.sh -b Release -d Nightly -p \"draco jayenne capsaicin\""
@@ -147,9 +147,9 @@ if [[ ${extra_params} ]]; then
    none)
       # if 'none' set to blank
       extra_params=""; epdash="" ;;
-   coverage | cuda | fulldiagnostics | nr | perfbench | pgi )
+   bounds_checking | clang | coverage | cuda | fulldiagnostics | knl | gcc530 )
       ;;
-   bounds_checking | gcc530 | clang | gcc610 )
+   gcc610 | nr | perfbench | pgi )
       ;;
    *)  echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
        print_use; exit 1 ;;
@@ -202,7 +202,7 @@ tt-*)
     if [[ ${extra_params} ]]; then
         case $extra_params in
         none) extra_params=""; epdash="" ;;
-        fulldiagnostics | nr | perfbench ) # known, continue
+        fulldiagnostics | knl | nr | perfbench ) # known, continue
         ;;
         *)  echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
             print_use; exit 1 ;;

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -40,14 +40,20 @@ run "module load user_contrib svn git"
 
 # Ensure that the permissions are correct
 run "umask 0002"
+svnhostmachine=ccscs7
 MYHOSTNAME=`uname -n`
 regdir=/usr/projects/jayenne/regress
 svnroot=$regdir/svn
-svnhostmachine=ccscs7
+VENDOR_DIR=/usr/projects/draco/vendors
+keychain=keychain-2.7.1
+
+if ! test -d $regdir; then
+  mkdir -p $regdir
+fi
 
 # Credentials via Keychain (SSH)
 # http://www.cyberciti.biz/faq/ssh-passwordless-login-with-keychain-for-scripts
-/usr/projects/draco/vendors/keychain-2.7.1/keychain $HOME/.ssh/cmake_dsa
+$VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa
 if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
     run "source $HOME/.keychain/$MYHOSTNAME-sh"
 else
@@ -61,15 +67,13 @@ fi
 if test -d $regdir/draco; then
   run "cd $regdir/draco; git pull"
 else
-  run "cd $regdir"
-  run "git clone https://github.com/losalamos/Draco.git draco"
+  run "cd $regdir; git clone https://github.com/losalamos/Draco.git draco"
 fi
 
-if test -d $regdir/jayenne/regression; then
-    run "cd $regdir/jayenne/regression; svn update"
+if test -d $regdir/jayenne; then
+  run "cd $regdir/jayenne; git pull"
 else
-    run "mkdir -p $regdir/jayenne; cd $regdir/jayenne"
-    run "svn co svn+ssh://$svnhostmachine/ccs/codes/radtran/svn/jayenne-project/regression"
+  run "cd $regdir; git clone git@gitlab.lanl.gov:jayenne/jayenne.git"
 fi
 
 if test -d $regdir/capsaicin/scripts; then
@@ -107,7 +111,6 @@ if ! test -d $svnroot; then
     # svnsync sync file:///${svnroot}/jayenne
 fi
 
-run "svnsync --non-interactive sync file:///${svnroot}/jayenne"
 run "svnsync --non-interactive sync file:///${svnroot}/capsaicin"
 
 #------------------------------------------------------------------------------#

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -7,10 +7,22 @@
 ##         All rights are reserved.
 ##---------------------------------------------------------------------------##
 
-# This script is used to mirror portions of the Jayenne and Capsaicin SVN
-# repositories to a HPC location. The repository must be mirrored because the
-# ctest regression system must be run from the HPC backend (via msub) where
-# access to ccscs7:/ccs/codes/radtran/svn is not available.
+# This script is used for 2 similar but distinct operations:
+#
+# 1. It mirrors portions of the Capsaicin SVN repositories to a HPC
+#    location. The repository must be mirrored because the ctest regression
+#    system must be run from the HPC backend (via msub) where access to
+#    ccscs7:/ccs/codes/radtran/svn is not available.
+# 2. It also mirrors git@github.com/losalamos/Draco.git and
+#    git@gitlab.lanl.gov/jayenne/jayenne.git to ccscs7:/ccs/codes/radtran/git.
+#    This is done to allow Redmine to parse the current repository preseting a
+#    GUI view and scraping commit information that connects to tracked issues.
+
+target="`uname -n | sed -e s/[.].*//`"
+MYHOSTNAME="`uname -n`"
+
+# Locate the directory that this script is located in:
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 #
 # MODULES
@@ -31,21 +43,29 @@ modcmd=`declare -f module`
 # Environment
 #
 
-run () {
-    echo $1
-    if ! test $dry_run; then eval $1; fi
-}
-
-run "module load user_contrib svn git"
+# import some bash functions
+source $scriptdir/scripts/common.sh
 
 # Ensure that the permissions are correct
 run "umask 0002"
 svnhostmachine=ccscs7
-MYHOSTNAME=`uname -n`
-regdir=/usr/projects/jayenne/regress
-svnroot=$regdir/svn
-VENDOR_DIR=/usr/projects/draco/vendors
-keychain=keychain-2.7.1
+
+case ${target} in
+ccscs*)
+    run "module load user_contrib subversion git"
+    regdir=/scratch/regress
+    gitroot=/ccs/codes/radtran/git
+    VENDOR_DIR=/scratch/vendors
+    keychain=keychain-2.8.2
+;;
+*)
+    run "module load user_contrib svn git"
+    regdir=/usr/projects/jayenne/regress
+    svnroot=$regdir/svn
+    VENDOR_DIR=/usr/projects/draco/vendors
+    keychain=keychain-2.7.1
+    ;;
+esac
 
 if ! test -d $regdir; then
   mkdir -p $regdir
@@ -54,15 +74,39 @@ fi
 # Credentials via Keychain (SSH)
 # http://www.cyberciti.biz/faq/ssh-passwordless-login-with-keychain-for-scripts
 $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa
+$VENDOR_DIR/$keychain/keychain $HOME/.ssh/id_dsa
 if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
     run "source $HOME/.keychain/$MYHOSTNAME-sh"
 else
     echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
 fi
 
-#
-# update the scripts directories in /usr/projects/jayenne
-#
+case ${target} in
+ccscs*)
+    # Keep local (ccscs7:/ccs/codes/radtran/git) copies of the github and gitlab
+    # repositories. This location can be parsed by redmine.
+    if test -d $gitroot/Draco.git; then
+      run "cd $gitroot/Draco.git"
+      run "git fetch origin +refs/heads/*:refs/heads/*"
+      run "git reset --soft"
+    else
+      run "mkdir -p $gitroot"
+      run "cd $gitroot"
+      run "git clone --bare git@github.com:losalamos/Draco.git Draco.git"
+    fi
+    if test -d $gitroot/jayenne.git; then
+      run "cd $gitroot/jayenne.git"
+      run "git fetch origin +refs/heads/*:refs/heads/*"
+      run "git reset --soft"
+    else
+      run "cd $gitroot"
+      run "git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne.git"
+    fi
+    ;;
+*)
+    #
+    # HPC: update the scripts directories in /usr/projects/jayenne
+    #
 
 if test -d $regdir/draco; then
   run "cd $regdir/draco; git pull"
@@ -112,6 +156,8 @@ if ! test -d $svnroot; then
 fi
 
 run "svnsync --non-interactive sync file:///${svnroot}/capsaicin"
+;;
+esac
 
 #------------------------------------------------------------------------------#
 # End sync_repository.sh

--- a/regression/tt-crontab
+++ b/regression/tt-crontab
@@ -1,5 +1,19 @@
 # crontab for tt-fey
 
+#------------------------------------------------------------------------------#
+# Regression Options:
+# -a build autodoc
+# -r use regress account
+# -b build_type: Release|Debug
+# -d dashboard:  Nightly|Experimental
+# -p projects:
+# -e extra args:
+#    cuda  - build portions of the code that work with CUDA
+#    pgi   - build with the PGI compiler
+#    nr    - build with non-reproducible option.
+#    fulldiagnostics - build with IEEE checks enabled
+#------------------------------------------------------------------------------#
+
 01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/tt-Debug-master.log
 
 01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/tt-Release-master.log

--- a/regression/tt-job-launch.sh
+++ b/regression/tt-job-launch.sh
@@ -52,6 +52,24 @@ if [[ ! ${logdir} ]]; then
     exit 1
 fi
 
+if test $subproj == draco || test $subproj == jayenne; then
+  if [[ ! ${featurebranch} ]]; then
+    echo "FATAL ERROR in ${scriptname}: You did not set 'featurebranch' in the environment!"
+    echo "printenv -> "
+    printenv
+  fi
+fi
+
+# What queue should we use
+#access_queue=""
+#if test -x /opt/MOAB/bin/drmgroups; then
+#   avail_queues=`/opt/MOAB/bin/drmgroups`
+avail_queues=`mdiag -u $LOGNAME | grep ALIST | sed -e 's/.*ALIST=//' | sed -e 's/,/ /g'`
+case $avail_queues in
+*access*) access_queue="-A access" ;;
+esac
+#fi
+
 # Banner
 echo "==========================================================================="
 echo "Trinitite Regression job launcher for ${subproj} - ${build_type} flavor."
@@ -64,6 +82,9 @@ if [[ ! ${extra_params} ]]; then
   echo "   extra_params   = none"
 else
   echo "   extra_params   = ${extra_params}"
+fi
+if [[ ${featurebranch} ]]; then
+  echo "   featurebranch  = ${featurebranch}"
 fi
 echo "   regdir         = ${regdir}"
 echo "   rscriptdir     = ${rscriptdir}"

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -48,7 +48,7 @@ export HTTPS_PROXY=$http_proxy
 # above proxy env variables before submitting the results to cdash.
 export no_proxy="localhost,127.0.0.1,rtt.lanl.gov,.lanl.gov"
 export NO_PROXY=$no_proxy
-export VENDOR_DIR=/scratch/vendors
+export VENDOR_DIR=/usr/projects/draco/vendors
 # gitlab.lanl.gov has an unkown certificate, disable checking
 export GIT_SSL_NO_VERIFY=true
 
@@ -127,7 +127,7 @@ export CC=`which cc`
 export CXX=`which CC`
 export FC=`which ftn`
 export CRAYPE_LINK_TYPE=dynamic
-    export OMP_NUM_THREADS=16
+export OMP_NUM_THREADS=16
 comp=CC
 
 # Extra parameers

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -47,7 +47,13 @@ export http_proxy=http://proxyout.lanl.gov:8080
 export HTTP_PROXY=$http_proxy
 export https_proxy=$http_proxy
 export HTTPS_PROXY=$http_proxy
-export VENDOR_DIR=/usr/projects/draco/vendors
+# ctest submit seems to ignore these no proxy settings, so we must unset the
+# above proxy env variables before submitting the results to cdash.
+export no_proxy="localhost,127.0.0.1,rtt.lanl.gov,.lanl.gov"
+export NO_PROXY=$no_proxy
+export VENDOR_DIR=/scratch/vendors
+# gitlab.lanl.gov has an unkown certificate, disable checking
+export GIT_SSL_NO_VERIFY=true
 
 # import some bash functions
 source $rscriptdir/scripts/common.sh
@@ -136,7 +142,7 @@ run "module unload xt-totalview xt-libsci "
 run "module list"
 
 # Use a unique regression folder for each github branch
-if test ${USE_GITHUB:-0} = 1; then
+if test ${USE_GITHUB:-0} == 1; then
   comp=$comp-$featurebranch
 fi
 

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -19,10 +19,6 @@ source $scriptdir/scripts/common.sh
 
 # Ensure that the permissions are correct
 case ${target} in
-  darwin-login*)
-    echo "Please run regressions from darwin-fe instead of darwin-login."
-    exit 1
-    ;;
   darwin-fe* | cn[0-9]*)
     # personal copy of ssh-agent.
     export PATH=$HOME/bin:$PATH
@@ -79,13 +75,13 @@ case ${target} in
     #   (run "cd $gitroot; git clone https://github.com/losalamos/Draco.git draco")
     # fi
 
-    run "${SVN}sync --non-interactive sync file://${svnroot}/jayenne"
     run "${SVN}sync --non-interactive sync file://${svnroot}/capsaicin"
     # (run "cd $gitroot/draco; git pull origin develop")
     ;;
   ccscs*)
     REGDIR=/scratch/regress
     SVN=/scratch/vendors/subversion-1.9.3/bin/svn
+    /scratch/vendors/keychain-2.8.2/keychain $HOME/.ssh/id_dsa
     /scratch/vendors/keychain-2.8.2/keychain $HOME/.ssh/cmake_dsa
     if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
        source $HOME/.keychain/$MYHOSTNAME-sh
@@ -99,8 +95,19 @@ case ${target} in
 esac
 
 # Update main regression scripts
-run "cd ${REGDIR}/draco; git pull"
-run "cd ${REGDIR}/jayenne/regression; ${SVN} update"
+if ! test -d $REGDIR; then
+  run "mkdir -p ${REGDIR}"
+fi
+if test -d ${REGDIR}/draco; then
+  run "cd ${REGDIR}/draco; git pull"
+else
+  run "cd ${REGDIR}; git clone https://github.com/losalamos/Draco.git draco"
+fi
+if test -d ${REGIDR}/jayenne; then
+  run "cd ${REGDIR}/jayenne; git pull"
+else
+  run "cd ${REGDIR}; git clone git@gitlab.lanl.gov:jayenne/jayenne.git"
+fi
 run "cd ${REGDIR}/capsaicin/scripts; ${SVN} update"
 
 ##---------------------------------------------------------------------------##

--- a/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh
+++ b/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh
@@ -27,18 +27,18 @@ namespace rtt_cdi_analytic
  */
 //===========================================================================//
 
-class DLL_PUBLIC_cdi_analytic nGray_Analytic_Odfmg_Opacity :
-        public Analytic_Odfmg_Opacity
+class DLL_PUBLIC_cdi_analytic nGray_Analytic_Odfmg_Opacity
+    : public Analytic_Odfmg_Opacity
 {
   public:
     // Useful typedefs.
-    typedef rtt_dsxx::SP<Analytic_Opacity_Model>       SP_Analytic_Model;
+    typedef rtt_dsxx::SP<Analytic_Opacity_Model> SP_Analytic_Model;
     typedef rtt_dsxx::SP<const Analytic_Opacity_Model> const_Model;
-    typedef std::vector<SP_Analytic_Model>             sf_Analytic_Model;
-    typedef std::vector<double>                        sf_double;
-    typedef std::vector<sf_double>                     vf_double;
-    typedef std::string                                std_string;
-    typedef std::vector<char>                          sf_char;
+    typedef std::vector<SP_Analytic_Model> sf_Analytic_Model;
+    typedef std::vector<double> sf_double;
+    typedef std::vector<sf_double> vf_double;
+    typedef std::string std_string;
+    typedef std::vector<char> sf_char;
 
   private:
     // Analytic models for each group.
@@ -46,23 +46,23 @@ class DLL_PUBLIC_cdi_analytic nGray_Analytic_Odfmg_Opacity :
 
   public:
     // Constructor.
-    nGray_Analytic_Odfmg_Opacity(
-        const sf_double         &groups,
-        const sf_double         &bands,
-        const sf_Analytic_Model &models,
-        rtt_cdi::Reaction        reaction_in,
-        rtt_cdi::Model           model_in = rtt_cdi::ANALYTIC);
+    nGray_Analytic_Odfmg_Opacity(const sf_double & groups,
+                                 const sf_double & bands,
+                                 const sf_Analytic_Model & models,
+                                 rtt_cdi::Reaction reaction_in,
+                                 rtt_cdi::Model model_in = rtt_cdi::ANALYTIC);
 
     // Constructor for packed nGray_Analytic_Odfmg_Opacities
     explicit nGray_Analytic_Odfmg_Opacity(const sf_char &);
 
     // >>> ACCESSORS
-    const_Model get_Analytic_Model(int g) const
-    { return group_models[g-1]; }
+    const_Model get_Analytic_Model(int g) const { return group_models[g - 1]; }
 
     //! right now, all bands have same model (same opacity)
     const_Model get_Analytic_Model(int g, int /*b*/) const
-    { return group_models[g-1]; }
+    {
+        return group_models[g - 1];
+    }
 
     // >>> INTERFACE SPECIFIED BY rtt_cdi::OdfmgOpacity
 
@@ -77,17 +77,16 @@ class DLL_PUBLIC_cdi_analytic nGray_Analytic_Odfmg_Opacity :
      *     value is being requested.
      * \return A vector of opacities.
      */
-    std::vector< std::vector<double> > getOpacity(
-        double targetTemperature,
-        double targetDensity ) const;
+    std::vector<std::vector<double>> getOpacity(double targetTemperature,
+                                                double targetDensity) const;
 
-    std::vector< std::vector< std::vector<double> > > getOpacity(
-        const std::vector<double>& targetTemperature,
-        double targetDensity ) const;
+    std::vector<std::vector<std::vector<double>>>
+    getOpacity(const std::vector<double> & targetTemperature,
+               double targetDensity) const;
 
-    std::vector< std::vector< std::vector<double> > > getOpacity(
-        double targetTemperature,
-        const std::vector<double>& targetDensity ) const;
+    std::vector<std::vector<std::vector<double>>>
+    getOpacity(double targetTemperature,
+               const std::vector<double> & targetDensity) const;
 
     // Get the data description of the opacity.
     inline std_string getDataDescriptor() const;
@@ -114,7 +113,7 @@ nGray_Analytic_Odfmg_Opacity::getDataDescriptor() const
     else if (reaction == rtt_cdi::SCATTERING)
         descriptor = "Analytic Odfmg Scattering";
     else
-        Insist (0, "Invalid analytic multigroup model opacity!");
+        Insist(0, "Invalid analytic multigroup model opacity!");
 
     return descriptor;
 }

--- a/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh
+++ b/src/cdi_analytic/nGray_Analytic_Odfmg_Opacity.hh
@@ -8,17 +8,11 @@
  *         All rights reserved.
  */
 //---------------------------------------------------------------------------//
-// $Id$
-//---------------------------------------------------------------------------//
 
 #ifndef __cdi_analytic_nGray_Analytic_Odfmg_Opacity_hh__
 #define __cdi_analytic_nGray_Analytic_Odfmg_Opacity_hh__
 
-#include "Analytic_Models.hh"
 #include "Analytic_Odfmg_Opacity.hh"
-#include "cdi/OpacityCommon.hh"
-#include "ds++/SP.hh"
-#include <string>
 
 namespace rtt_cdi_analytic
 {
@@ -31,10 +25,10 @@ namespace rtt_cdi_analytic
  *
  * Primarily code from Analytic_Multigroup_Opacity.
  */
-//
 //===========================================================================//
 
-class DLL_PUBLIC_cdi_analytic nGray_Analytic_Odfmg_Opacity : public Analytic_Odfmg_Opacity
+class DLL_PUBLIC_cdi_analytic nGray_Analytic_Odfmg_Opacity :
+        public Analytic_Odfmg_Opacity
 {
   public:
     // Useful typedefs.
@@ -120,9 +114,7 @@ nGray_Analytic_Odfmg_Opacity::getDataDescriptor() const
     else if (reaction == rtt_cdi::SCATTERING)
         descriptor = "Analytic Odfmg Scattering";
     else
-    {
         Insist (0, "Invalid analytic multigroup model opacity!");
-    }
 
     return descriptor;
 }


### PR DESCRIPTION
First cut at updating the regression system to pull jayenne from gitlab.  This should fix regressions on ccscs7, Moonlight and Trinitite.  I will use a 2nd iteration to patch the regression system for darwin and win32.
    
* Provide additional documention about proxy variables found in the draco environment.
* Update sample crontab for ccscs-net servers.  Show commands for integrating gitlab and github repositories with redmine.  We must have a local checkout to allow redmine integration.  These directories are stored at `/ccs/codes/radtran/git.`
* Update the regression system to respect multiple values provided to option `-f`. These are featurebranch values like pr numbers.  By default these are set to `develop`.
* Provide extra logic to set the compiler version as part of the build name shown on cdash.
* Teach the ctest scripts to clone jayenne from gitlab.
* Teach the regression system about jayenne pull requests by updating the helper script fetch_co.sh to take an extra argument that is used to differentiate between github and gitlab and by updating the logic in `draco_regression_macros` to pass the new argument to `fetch_co.sh.`
* This implementation supports running the regression in the following modes:
    
|      mode  |     description  |
|      ------- |   ------------------- |
|      normal |    test draco 'develop' branch w/o jayenne |
|      normal  |   both draco and jayenne are branch 'develop' |
|      draco pr |  test draco 'pr' branch w/o jayenne |
|      jayenne pr | test jayenne 'pr' branch linking to draco develop |
    
* Modes that are not yet supported:
  * `draco pr + jayenne pr` --> Ensure draco pr is good and merged before jayenne pr is reviewed.
  * `jayenne develop against draco pr.` --> might be good to have.
* Cosmetic changes to a few files.
