### PR TITLE
Merging regression script changes required for ML and TT.

### DIFF
--- a/regression/ml-crontab
+++ b/regression/ml-crontab
@@ -1,9 +1,13 @@
 # crontab for ml-fey
 
-01 22 * * 0-6 /usr/projects/jayenne/regress/draco/regression/sync_repository.sh &> /usr/projects/jayenne/regress/logs/ml_sync_repo.log
+# Create a svn hotcopy of capsaicin at /usr/projects/jayenne/regress/svn
+01 22 * * 0-6 /usr/projects/jayenne/regress/draco/regression/sync_repository.sh &> /usr/projects/jayenne/regress/logs/sync_repository.log
+
+# Update the run scripts in the regression directory
+01 23 * * 0-6 /usr/projects/jayenne/regress/draco/regression/update_regression_scripts.sh &> /usr/projects/jayenne/regress/logs/update_regression_scripts.log
 
 #------------------------------------------------------------------------------#
-# CUDA (Intel/15.0.5 and OpenMPI/1.6.5)
+# Regressions options:
 # -a build autodoc
 # -r use regress account
 # -b build_type: Release|Debug
@@ -16,17 +20,21 @@
 #    fulldiagnostics - build with IEEE checks enabled
 #------------------------------------------------------------------------------#
 
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e cuda -p "draco jayenne" &> /usr/projects/jayenne/regress/logs/ml-Debug-cuda-master.log
+#------------------------------------------------------------------------------#
+# CUDA (Intel/15.0.5 and OpenMPI/1.6.5 and CUDA)
+#------------------------------------------------------------------------------#
 
-01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e cuda -p "draco jayenne" &> /usr/projects/jayenne/regress/logs/ml-Release-cuda-master.log
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e cuda -p "draco jayenne" &> /usr/projects/jayenne/regress/logs/ml-Debug-cuda-master.log
+
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e cuda -p "draco jayenne" &> /usr/projects/jayenne/regress/logs/ml-Release-cuda-master.log
 
 #------------------------------------------------------------------------------#
 # Intel/16.0.3 and OpenMPI/1.10.1
 #------------------------------------------------------------------------------#
 
-01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/ml-Debug-master.log
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/ml-Debug-master.log
 
-01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/ml-Release-master.log
+01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/ml-Release-master.log
 
 #------------------------------------------------------------------------------#
 # Github and PRs
@@ -48,9 +56,9 @@
 
 01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e nr -p "jayenne" &> /usr/projects/jayenne/regress/logs/ml-Release-nr-master.log
 
-01 04 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e perfbench -p "capsaicin" &> /usr/projects/jayenne/regress/logs/ml-Release-perfbench-master.log
+01 03 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e perfbench -p "capsaicin" &> /usr/projects/jayenne/regress/logs/ml-Release-perfbench-master.log
 
-01 04 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e fulldiagnostics -p "draco jayenne capsaicin"  &> /usr/projects/jayenne/regress/logs/ml-Debug-fulldiagnostics-master.log
+01 01 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e fulldiagnostics -p "draco jayenne capsaicin"  &> /usr/projects/jayenne/regress/logs/ml-Debug-fulldiagnostics-master.log
 
 #------------------------------------------------------------------------------#
 # Periodic usage reports

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -50,7 +50,7 @@ export HTTPS_PROXY=$http_proxy
 # above proxy env variables before submitting the results to cdash.
 export no_proxy="localhost,127.0.0.1,rtt.lanl.gov,.lanl.gov"
 export NO_PROXY=$no_proxy
-export VENDOR_DIR=/scratch/vendors
+export VENDOR_DIR=/usr/projects/draco/vendors
 # gitlab.lanl.gov has an unkown certificate, disable checking
 export GIT_SSL_NO_VERIFY=true
 
@@ -167,6 +167,19 @@ run "module list"
 # Use a unique regression folder for each github branch
 if test ${USE_GITHUB:-0} == 1; then
   comp=$comp-$featurebranch
+fi
+
+# When run by crontab, use a special ssh-key to allow authentication to gitlab
+if test "$USER" == "kellyt"; then
+  run "module load git"
+  MYHOSTNAME="`uname -n`"
+  keychain=keychain-2.7.1
+  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa
+  if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
+    run "source $HOME/.keychain/$MYHOSTNAME-sh"
+  else
+    echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+  fi
 fi
 
 # ----------------------------------------

--- a/regression/tt-regress.msub
+++ b/regression/tt-regress.msub
@@ -153,6 +153,19 @@ if test ${USE_GITHUB:-0} == 1; then
   comp=$comp-$featurebranch
 fi
 
+# When run by crontab, use a special ssh-key to allow authentication to gitlab
+if test "$USER" == "kellyt"; then
+  run "module load git"
+  MYHOSTNAME="`uname -n`"
+  keychain=keychain-2.7.1
+  $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa
+  if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
+    run "source $HOME/.keychain/$MYHOSTNAME-sh"
+  else
+    echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+  fi
+fi
+
 # ----------------------------------------
 # Run the CTest script:
 # ----------------------------------------

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -8,9 +8,7 @@
 ##---------------------------------------------------------------------------##
 
 umask 0002
-
 target="`uname -n | sed -e s/[.].*//`"
-MYHOSTNAME="`uname -n`"
 
 # Locate the directory that this script is located in:
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -18,74 +16,28 @@ scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # import some bash functions
 source $scriptdir/scripts/common.sh
 
-# Ensure that the permissions are correct
+# Per machine setup
 case ${target} in
   darwin-fe* | cn[0-9]*)
+    REGDIR=/usr/projects/draco/regress
+    keychain=keychain-2.7.1
+    VENDOR_DIR=/usr/projects/draco/vendors
     # personal copy of ssh-agent.
     export PATH=$HOME/bin:$PATH
-    /usr/projects/draco/vendors/keychain-2.7.1/keychain $HOME/.ssh/cmake_dsa
-    if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
-       source $HOME/.keychain/$MYHOSTNAME-sh
-    fi
-
-    # Load keytab: (see notes at draco/regression/push_repositories_xf.sh)
-    # Use a different cache location to avoid destroying any active user's
-    # kerberos.
-    # export KRB5CCNAME=/tmp/regress_kerb_cache
-    # Obtain kerberos authentication via keytab
-    # run "kinit -l 1h -kt $HOME/.ssh/xfkeytab transfer/${USER}push@lanl.gov"
-
-    #module unload subversion
-    #module load subversion
     if test -d /projects/opt/centos7/subversion/1.9.2/bin; then
       export PATH=/projects/opt/centos7/subversion/1.9.2/bin:$PATH
     fi
     SVN=`which svn`
-    # SVN=/projects/opt/centos7/subversion/1.9.2/bin/svnsync
-    REGDIR=/usr/projects/draco/regress
-
-    svnroot=/usr/projects/draco/regress/svn
-    gitroot=/usr/projects/draco/regress/git
-    if ! test -d; then
-      echo "*** SVN repository not found ***"
-      exit 1
-      # http://journal.paul.querna.org/articles/2006/09/14/using-svnsync/
-      # mkdir -p ${svnroot}; cd ${svnroot}
-      # svnadmin create ${svnroot}/jayenne
-      # chgrp -R draco jayenne; chmod -R g+rwX,o=g-w jayenne
-      # cd jayenne/hooks
-      # cp pre-commit.tmpl pre-commit; chmod 775 pre-commit
-      # vi pre-commit; comment out all code and add...
-      #if ! test `whoami` = 'kellyt'; then
-      #echo "This is a read only repository.  The real SVN repository is"
-      #echo "at svn+ssh://ccscs7/ccs/codes/radtran/svn/draco."
-      #exit 1
-      #fi
-      #exit 0
-      # cp pre-revprop-change.tmpl pre-revprop-change; chmod 775 \
-      #    pre-revprop-change
-      # vi pre-revprop-change --> comment out all code.
-      # cd $svnroot
-      # svnsync init file:///${svnroot}/jayenne svn+ssh://ccscs7/ccs/codes/radtran/svn/jayenne
-      # svnsync sync file:///${svnroot}/jayenne
-    fi
-    # if ! test -d $gitroot; then
-    #   export https_proxy=http://proxyout.lanl.gov:8080
-    #   export HTTPS_PROXY=$https_proxy
-    #   run "mkdir -p $gitroot"
-    #   (run "cd $gitroot; git clone https://github.com/losalamos/Draco.git draco")
-    # fi
-
-    run "${SVN}sync --non-interactive sync file://${svnroot}/capsaicin"
-    # (run "cd $gitroot/draco; git pull origin develop")
     ;;
   ccscs*)
     REGDIR=/scratch/regress
     SVN=/scratch/vendors/subversion-1.9.3/bin/svn
-    /scratch/vendors/keychain-2.8.2/keychain $HOME/.ssh/cmake_dsa
-    if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
-       source $HOME/.keychain/$MYHOSTNAME-sh
-    fi
+    ;;
+  ml-*)
+    REGDIR=/usr/projects/jayenne/regress
+    keychain=keychain-2.7.1
+    VENDOR_DIR=/usr/projects/draco/vendors
+    SVN=/usr/projects/hpcsoft/toss2/common/subversion/1.9.1/bin/svn
     ;;
   *)
     # module load user_contrib subversion
@@ -94,7 +46,22 @@ case ${target} in
     ;;
 esac
 
-# Update main regression scripts
+# Load some identities used for accessing gitlab.
+MYHOSTNAME="`uname -n`"
+$VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa
+if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
+    run "source $HOME/.keychain/$MYHOSTNAME-sh"
+else
+    echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+fi
+
+# ---------------------------------------------------------------------------- #
+# Update the regression script directories
+# ---------------------------------------------------------------------------- #
+
+# Draco
+echo " "
+echo "Updating $REGDIR/draco..."
 if ! test -d $REGDIR; then
   run "mkdir -p ${REGDIR}"
 fi
@@ -103,12 +70,25 @@ if test -d ${REGDIR}/draco; then
 else
   run "cd ${REGDIR}; git clone https://github.com/losalamos/Draco.git draco"
 fi
+
+# Jayenne
+echo " "
+echo "Updating $REGDIR/jayenne..."
 if test -d ${REGDIR}/jayenne; then
   run "cd ${REGDIR}/jayenne; git pull"
 else
   run "cd ${REGDIR}; git clone git@gitlab.lanl.gov:jayenne/jayenne.git"
 fi
-run "cd ${REGDIR}/capsaicin/scripts; ${SVN} update"
+
+# Capsaicin
+echo " "
+echo "Updating $REGDIR/capsaicin..."
+if test -d ${REGDIR}/capsaicin/scripts; then
+  run "cd ${REGDIR}/capsaicin/scripts; svn update"
+else
+  run "mkdir -p ${REGDIR}/capsaicin; cd ${REGDIR}/capsaicin"
+  run "svn co svn+ssh://ccscs7.lanl.gov/ccs/codes/radtran/svn/capsaicin/trunk/scripts"
+fi
 
 ##---------------------------------------------------------------------------##
 ## End update_regression_scripts.sh


### PR DESCRIPTION
* These ran successfully last night.
* De-tangle the reponsibilities of `sync_repository.sh` and `update_regression_scripts.sh`.
  * `sync_repository.sh` only touches copies of repositories that are mirrored to local file systems.
  * `update_regression_scripts.sh` only updates the regression scripts on each machine that are located at `$regdir` (`/scratch/regress,` `/usr/projects/jayenne/regress,` etc.).
* Add keychain setup to `tt-regress.msub` and `ml-regress.msub.` This allows the crontab to access `gitlab.lanl.gov:jayenne/jayenne.git.`
* Fix a bug in ml-regress that set the `VENDOR_DIR` to the wrong location (cut & paste error).