### PR TITLE
Minor cleanup of regression scripts for Win32 platforms.

### DIFF
--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -740,7 +740,7 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
   string( TOUPPER ${dep_pkg} dep_pkg_caps )
   # Assume that draco_work_dir is parallel to our current location, but
   # only replace the directory name preceeding the dashboard name.
-  file( TO_CMAKE_PATH $ENV{work_dir} work_dir )
+  file( TO_CMAKE_PATH "$ENV{work_dir}" work_dir )
   message("work_dir = ${work_dir}")
   string( REGEX REPLACE "${this_pkg}[/\\](Nightly|Experimental|Continuous)" "${dep_pkg}/\\1"
     ${dep_pkg}_work_dir ${work_dir} )
@@ -752,8 +752,9 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
     # nr        build -> release version of Draco
     # perfbench build -> release version of Draco
     # string( REPLACE "Coverage" "Debug"  ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
-    string( REPLACE "intel-nr" "icpc" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
+    string( REPLACE "intel-nr"        "icpc" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     string( REPLACE "intel-perfbench" "icpc" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
+
     if( "${this_pkg}" MATCHES "jayenne" )
       # If this is jayenne, we might be building a pull request. Replace the PR
       # number in the path with '-develop' before looking for draco.

--- a/regression/update_regression_dir.bat
+++ b/regression/update_regression_dir.bat
@@ -1,4 +1,12 @@
 @echo off
+rem ---------------------------------------------------------------------------
+rem File  : regression/update_regrssion_dir.bat
+rem Date  : Tuesday, May 31, 2016, 14:48 pm
+rem Author: Kelly Thompson
+rem Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+rem         All rights are reserved.
+rem ---------------------------------------------------------------------------
+
 set LOGDIR=e:\regress\logs
 set GIT="c:\\Program Files\\Git\\bin\\git.exe"
 echo cd e:\regress\draco

--- a/regression/win32-regress.bat
+++ b/regression/win32-regress.bat
@@ -1,14 +1,20 @@
 @echo off
-rem This file copied from c:\program files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
+rem ---------------------------------------------------------------------------
+rem File  : regression/win32-regress.bat
+rem Date  : Tuesday, May 31, 2016, 14:48 pm
+rem Author: Kelly Thompson
+rem Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+rem         All rights are reserved.
+rem ---------------------------------------------------------------------------
 
-REM %comspec% /[k|c] ""C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" x86
-
-rem capture all output from batch file like this...
-rem win32_draco_regression.bat > mylog.txt 2>&1
-
-rem In Task Scheduler, create to actions:
-rem 1. d:\regress\draco\regression\update_regression_dir.bat
-rem 2. c:\windows\system32\cmd.exe /k ""d:\regress\draco\regression\win32_draco_regression.bat"" x86
+rem This file copied from c:\program files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat.  
+rem It establishes a Visual Studio environment in a command prompt.  The 
+rem Windows shortcut runs the following command:
+rem
+rem %comspec% /[k|c] ""C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" x86
+rem
+rem This fill is called from win32-regression-master.bat so that all outpout
+rem can be captured in a log file.
 
 if "%1" == "" goto x86
 if not "%2" == "" goto usage
@@ -52,12 +58,6 @@ rem ----------------------------------------------------------------------------
 
 :vendorsetup
 call e:\work\vendors\setupvendors.bat
-REM set PATH=%PATH%;c:\MinGW\bin
-REM set VENDOR_DIR=e:\work\vendors
-REM set GSL_ROOT_DIR=%VENDOR_DIR%\gsl-1.16
-REM set LAPACK_LIB_DIR=%VENDOR_DIR%\lapack-3.4.2\lib
-REM set LAPACK_INC_DIR=%VENDOR_DIR%\lapack-3.4.2\include
-REM set QTDIR=c:/Qt/5.3/msvc2013
 set USE_GITHUB=1
 
 :cdash

--- a/regression/win32-regression-master.bat
+++ b/regression/win32-regression-master.bat
@@ -1,6 +1,19 @@
 @echo off
+rem ---------------------------------------------------------------------------
+rem File  : regression/win32-regression-master.bat
+rem Date  : Tuesday, May 31, 2016, 14:48 pm
+rem Author: Kelly Thompson
+rem Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+rem         All rights are reserved.
+rem ---------------------------------------------------------------------------
 
-%comspec% /c ""e:\regress\draco\regression\win32-regress.bat"" x86 > e:\regress\logs\regression-master.log
+rem Use Task Scheduler to create a task that runs this script every night at 
+rem midnight.
+
+set logdir=e:\regress\logs
+
+%comspec% /c ""e:\regress\draco\regression\update_regression_dir.bat"" x86 > %logdir%\update_regression_dir.log 2>&1
+%comspec% /c ""e:\regress\draco\regression\win32-regress.bat"" x86 > %logdir%\regression-master.log 2>&1
 rem %comspec% /k ""e:\regress\draco\regression\win32-regress.bat"" x86
 
 rem c:\myscript.%date:~-4%%date:~4,2%%date:~7,2%.%time::=%.log 2>&1


### PR DESCRIPTION
+ Add some double quotes around variables that contain paths that might have spaces.
+ Add header comment block to DOS batch files.
+ Use the regression-master.bat to kick off the update_regression_dir.bat.  This makes it easier to capture the output to a log file.