### PR TITLE
Point to a newer svn when running on Moonlight.

### DIFF
--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -84,10 +84,10 @@ fi
 echo " "
 echo "Updating $REGDIR/capsaicin..."
 if test -d ${REGDIR}/capsaicin/scripts; then
-  run "cd ${REGDIR}/capsaicin/scripts; svn update"
+  run "cd ${REGDIR}/capsaicin/scripts; ${SVN} update"
 else
   run "mkdir -p ${REGDIR}/capsaicin; cd ${REGDIR}/capsaicin"
-  run "svn co svn+ssh://ccscs7.lanl.gov/ccs/codes/radtran/svn/capsaicin/trunk/scripts"
+  run "${SVN} co svn+ssh://ccscs7.lanl.gov/ccs/codes/radtran/svn/capsaicin/trunk/scripts"
 fi
 
 ##---------------------------------------------------------------------------##


### PR DESCRIPTION
+ The default svn on Moonlight is too old to work with the Capsaicin repository. Use subversion-1.9.1 when updating the regression scripts.