### PR TITLE
Download jayenne PRs to the local filesystem nightly.

### DIFF
--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -35,11 +35,11 @@ scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 modcmd=`declare -f module`
 # If not found, look for it in /usr/share/Modules (ML)
 if [[ ! ${modcmd} ]]; then
-   if test -f /usr/share/Modules/init/bash; then
-      source /usr/share/Modules/init/bash
-   else
-      echo "ERROR: The module command was not found. No modules will be loaded."
-   fi
+  if test -f /usr/share/Modules/init/bash; then
+    source /usr/share/Modules/init/bash
+  else
+    echo "ERROR: The module command was not found. No modules will be loaded."
+  fi
 fi
 modcmd=`declare -f module`
 
@@ -87,9 +87,9 @@ fi
 MYHOSTNAME="`uname -n`"
 $VENDOR_DIR/$keychain/keychain $HOME/.ssh/cmake_dsa
 if test -f $HOME/.keychain/$MYHOSTNAME-sh; then
-    run "source $HOME/.keychain/$MYHOSTNAME-sh"
+  run "source $HOME/.keychain/$MYHOSTNAME-sh"
 else
-    echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
+  echo "Error: could not find $HOME/.keychain/$MYHOSTNAME-sh"
 fi
 
 # ---------------------------------------------------------------------------- #
@@ -97,7 +97,7 @@ fi
 # ---------------------------------------------------------------------------- #
 
 case ${target} in
-ccscs*)
+  ccscs*)
     # Keep local (ccscs7:/ccs/codes/radtran/git) copies of the github and gitlab
     # repositories. This location can be parsed by redmine.
 
@@ -106,6 +106,7 @@ ccscs*)
     if test -d $gitroot/Draco.git; then
       run "cd $gitroot/Draco.git"
       run "git fetch origin +refs/heads/*:refs/heads/*"
+      run "git fetch origin +refs/pull/*:refs/pull/*"
       run "git reset --soft"
     else
       run "mkdir -p $gitroot"
@@ -118,13 +119,14 @@ ccscs*)
     if test -d $gitroot/jayenne.git; then
       run "cd $gitroot/jayenne.git"
       run "git fetch origin +refs/heads/*:refs/heads/*"
+      run "git fetch origin +refs/merge-requests/*:refs/merge-requets/*"
       run "git reset --soft"
     else
       run "mkdir -p $gitroot; cd $gitroot"
       run "git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne.git"
     fi
     ;;
-darwin-fe*)
+  darwin-fe*)
     # Keep local (ccscs7:/ccs/codes/radtran/git) copies of the github and gitlab
     # repositories. This location can be parsed by redmine. For darwin, the
     # backend can't see gitlab, so keep a copy of the repository local.
@@ -154,7 +156,7 @@ darwin-fe*)
       run "git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne.git"
     fi
     ;;
-*)
+  *)
     #
     # HPC: Mirror the capsaicin svn repository
     #

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -8,6 +8,7 @@
 ##---------------------------------------------------------------------------##
 
 umask 0002
+
 target="`uname -n | sed -e s/[.].*//`"
 
 # Locate the directory that this script is located in:
@@ -37,6 +38,7 @@ case ${target} in
     ;;
   ccscs*)
     REGDIR=/scratch/regress
+    keychain=keychain-2.8.2
     SVN=/scratch/vendors/subversion-1.9.3/bin/svn
     ;;
   ml-*)
@@ -76,7 +78,6 @@ if test -d ${REGDIR}/draco; then
 else
   run "cd ${REGDIR}; git clone https://github.com/losalamos/Draco.git draco"
 fi
-
 # Deal with proxy stuff on darwin
 case ${target} in
   darwin-fe* | cn[0-9]*)
@@ -97,12 +98,11 @@ if test -d ${REGDIR}/jayenne; then
 else
   run "cd ${REGDIR}; git clone git@gitlab.lanl.gov:jayenne/jayenne.git"
 fi
-
 # Capsaicin
 echo " "
 echo "Updating $REGDIR/capsaicin..."
 if test -d ${REGDIR}/capsaicin/scripts; then
-  run "cd ${REGDIR}/capsaicin/scripts; ${SVN} update"
+run "cd ${REGDIR}/capsaicin/scripts; ${SVN} update"
 else
   run "mkdir -p ${REGDIR}/capsaicin; cd ${REGDIR}/capsaicin"
   run "${SVN} co svn+ssh://ccscs7.lanl.gov/ccs/codes/radtran/svn/capsaicin/trunk/scripts"


### PR DESCRIPTION
+ In addition to mirroring the Jayenne gitlab repository to the local file system (/ccs/codes/radtran/git/jayenne), download all PR branches. This serves as a local backup of the gitlab repository and allows us to easily copy a PR to the red network. Ditto for Draco on github.
+ Set the path to keychain for ccs machines.
+ Minor formatting changes.
