### PR TITLE
Mods needed for gitlab CI

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -177,15 +177,18 @@ macro( setupOpenMPI )
   # Setting mpi_paffinity_alone to 0 allows parallel ctest to
   # work correctly.  MPIEXEC_POSTFLAGS only affects MPI-only
   # tests (and not MPI+OpenMP tests).
+  if( "$ENV{GITLAB_CI}" STREQUAL "true" )
+    set(runasroot "--allow-run-as-root")
+  endif()
 
   # This flag also shows up in
   # jayenne/pkg_tools/run_milagro_test.py and regress_funcs.py.
   if( ${DBS_MPI_VER_MAJOR}.${DBS_MPI_VER_MINOR} VERSION_LESS 1.7 )
-    set( MPIEXEC_POSTFLAGS "--mca mpi_paffinity_alone 0" CACHE
+    set( MPIEXEC_POSTFLAGS "--mca mpi_paffinity_alone 0 ${runasroot}" CACHE
       STRING "extra mpirun flags (list)." FORCE)
   else()
     # Flag provided by Sam Gutierrez (2015-04-08),
-    set( MPIEXEC_POSTFLAGS "-mca hwloc_base_binding_policy none" CACHE
+    set( MPIEXEC_POSTFLAGS "-mca hwloc_base_binding_policy none ${runasroot}" CACHE
       STRING "extra mpirun flags (list)." FORCE)
   endif()
 
@@ -202,7 +205,7 @@ macro( setupOpenMPI )
     if( NOT APPLE )
       # -bind-to fails on OSX, See #691
       set( MPIEXEC_OMP_POSTFLAGS
-        "-bind-to socket --map-by ppr:${MPI_CORES_PER_CPU}:socket --report-bindings" )
+        "-bind-to socket --map-by ppr:${MPI_CORES_PER_CPU}:socket --report-bindings ${runasroot}" )
     endif()
   else()  # Version 1.7.4
     set( MPIEXEC_OMP_POSTFLAGS

--- a/regression/metrics_report.sh
+++ b/regression/metrics_report.sh
@@ -27,7 +27,7 @@ print_use()
 ## Sanity Checks and Setup
 ##---------------------------------------------------------------------------##
 
-if test "${4}x" = "x"; then
+if [[ ! ${4} ]]; then
    echo "ERROR: You must provide at least 4 arguments."
    print_use
    exit 1


### PR DESCRIPTION
+ Gitlab CI uses a docker on darwin. CI sessions run as root, but openmpi refuses to run as root w/o the mpirun option '--allow-run-as-root'. Add this option on unit tests if the environment variable GITLAB_CI is defined.