### PR TITLE
Make DynamicAnalysis an explicit option for the regression system.

### DIFF
--- a/regression/Draco_Linux64.cmake
+++ b/regression/Draco_Linux64.cmake
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.0.0)
 #   [export work_dir=/full/path/to/working/dir]
 #   ctest [-V] [-VV] -S /path/to/this/script.cmake,\
 #     [Experimental|Nightly|Continuous],\
-#     [Debug[,Coverage]|Release|RelWithDebInfo]
+#     [Debug[,Coverage|,DynamicAnalysis]|Release|RelWithDebInfo]
 
 set( CTEST_PROJECT_NAME "Draco" )
 message("source ${CTEST_SCRIPT_DIRECTORY}/draco_regression_macros.cmake" )

--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -32,25 +32,27 @@
 
 00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e bounds_checking &> /scratch/regress/logs/ccscs-Debug-master-bounds_checking.log
 
+00 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e valgrind &> /scratch/regress/logs/ccscs-Debug-master-valgrind.log
+
 #------------------------------------------------------------------------------#
 # Clang-3.8.0, gcc-5.3.0, gcc-6.1.0
 #------------------------------------------------------------------------------#
 
-00 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e clang &> /scratch/regress/logs/ccscs-Debug-clang-master.log
+00 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e clang &> /scratch/regress/logs/ccscs-Debug-clang-master.log
 
-00 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc530 &> /scratch/regress/logs/ccscs-Debug-gcc530-master.log
+00 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc530 &> /scratch/regress/logs/ccscs-Debug-gcc530-master.log
 
-00 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc610 &> /scratch/regress/logs/ccscs-Debug-gcc610-master.log
+00 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc610 &> /scratch/regress/logs/ccscs-Debug-gcc610-master.log
 
 #------------------------------------------------------------------------------#
 # Special build for a Pull Request that is under consideration
 #------------------------------------------------------------------------------#
 
 # Build both draco and jayenne from PRs.
-# 05 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Experimental -p "draco jayenne" -f "develop pr42" &> /scratch/regress/logs/ccscs-Release-master-pr1.log
+# 05 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -b Release -p "draco jayenne" -f "develop pr42" &> /scratch/regress/logs/ccscs-Release-master-pr1.log
 
 # Build jayenne from PR (use develop for draco)
-# 05 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Release -d Experimental -p "draco" -f "pr42" &> /scratch/regress/logs/ccscs-Release-master-pr1.log
+# 05 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -b Release -p "draco" -f "pr42" &> /scratch/regress/logs/ccscs-Release-master-pr1.log
 
 # |    |    |    |    |   |
 # |    |    |    |    |   +- command

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -178,6 +178,14 @@ gcc530bc)
     run "module load ndi metis parmetis trilinos"
     comp=gcc-6.1.0
   ;;
+valgrind)
+  echo "Dynamic Analysis (valgrind) option selected."
+  if ! test "${build_type}" == "Debug"; then
+    echo "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
+    exit 1
+  fi
+  build_type=DynamicAnalysis
+  ;;
 *)
     echo "FATAL ERROR"
     echo "Extra parameter = ${extra_param} requested but is unknown to"
@@ -220,7 +228,7 @@ fi
 # Build type     : Release, Debug, Coverage
 
 if [[ ! ${dashboard_type} ]]; then
-   dashboard_type=Nightly
+   dashboard_type=Experimental
 fi
 if [[ ! ${base_dir} ]]; then
    if test "${regress_mode}" = "off"; then
@@ -300,6 +308,10 @@ if test "${build_type}" = "Coverage"; then
       run "rm -f ${COVFILE}"
       cov01 --on
    fi
+fi
+if test "${build_type}" = "DynamicAnalysis"; then
+   # DynamicAnalysis builds imply Debug builds.
+   build_type="Debug,${build_type}"
 fi
 if test "${bounds_checking:-off}" = "on"; then
     build_type="${build_type},bounds_checking"

--- a/regression/darwin-regress.msub
+++ b/regression/darwin-regress.msub
@@ -135,7 +135,7 @@ fi
 # Build type     : Release, Debug
 
 if [[ ! ${dashboard_type} ]]; then
-   dashboard_type=Nightly
+   dashboard_type=Experimental
 fi
 if [[ ! ${base_dir} ]]; then
   if test "${regress_mode}" = "off"; then

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -197,7 +197,7 @@ fi
 # Build type     : Release, Debug
 
 if [[ ! ${dashboard_type} ]]; then
-   dashboard_type=Nightly
+   dashboard_type=Experimental
 fi
 if [[ ! ${base_dir} ]]; then
    # Keep build and target dirs out of /usr/projects locations to

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -24,10 +24,10 @@ set -m
 print_use()
 {
     echo " "
-    echo "Usage: ${0##*/} -b [Release|Debug] -d [Experimental|Nightly]"
+    echo "Usage: ${0##*/} -b [Release|Debug] -d [Experimental|Nightly|Continuous]"
     echo "       -h -p [\"draco jayenne capsaicin\"] -r"
     echo "       -f <git branch name> -a"
-    echo "       -e [none|clang|coverage|cuda|fulldiagnostics|gcc530|gcc610|nr|perfbench|pgi]"
+    echo "       -e [none|clang|coverage|cuda|fulldiagnostics|gcc530|gcc610|nr|perfbench|pgi|valgrind]"
     echo " "
     echo "All arguments are optional,  The first value listed is the default value."
     echo "   -h    help           prints this message and exits."
@@ -35,14 +35,14 @@ print_use()
     echo " "
     echo "   -a    build autodoc"
     echo "   -b    build-type     = { Debug, Release }"
-    echo "   -d    dashboard type = { Experimental, Nightly }"
+    echo "   -d    dashboard type = { Experimental, Nightly, Continuous }"
     echo "   -f    git feature branch, default=\"develop develop\""
     echo "         common: 'develop pr42'"
     echo "         requires one string per project listed in option -p"
     echo "   -p    project names  = { draco, jayenne, capsaicin }"
     echo "                          This is a space delimited list within double quotes."
     echo "   -e    extra params   = { none, clang, coverage, cuda, fulldiagnostics,"
-    echo "                            knl, gcc530, gcc610, nr, perfbench, pgi}"
+    echo "                            knl, gcc530, gcc610, nr, perfbench, pgi, valgrind}"
     echo " "
     echo "Example:"
     echo "./regression-master.sh -b Release -d Nightly -p \"draco jayenne capsaicin\""
@@ -65,7 +65,7 @@ fn_exists()
 ##---------------------------------------------------------------------------##
 build_autodoc="off"
 build_type=Debug
-dashboard_type=Nightly
+dashboard_type=Experimental
 projects="draco"
 extra_params=""
 regress_mode="off"
@@ -127,7 +127,7 @@ case ${build_type} in
 esac
 
 case ${dashboard_type} in
-Nightly | Experimental) # known dashboard_type, continue
+Nightly | Experimental | Continuous) # known dashboard_type, continue
     ;;
 *)  echo "" ;echo "FATAL ERROR: unknown dashboard_type (-d) = ${dashboard_type}"
     print_use; exit 1 ;;
@@ -149,7 +149,7 @@ if [[ ${extra_params} ]]; then
       extra_params=""; epdash="" ;;
    bounds_checking | clang | coverage | cuda | fulldiagnostics | knl | gcc530 )
       ;;
-   gcc610 | nr | perfbench | pgi )
+   gcc610 | nr | perfbench | pgi | valgrind )
       ;;
    *)  echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
        print_use; exit 1 ;;
@@ -187,7 +187,7 @@ ml-*)
     if [[ ${extra_params} ]]; then
         case $extra_params in
         none)  extra_params=""; epdash="" ;;
-        cuda | fulldiagnostics | nr | perfbench | pgi ) # known, continue
+        cuda | fulldiagnostics | nr | perfbench | pgi | valgrind ) # known, continue
         ;;
         *) echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
            print_use; exit 1 ;;
@@ -219,7 +219,7 @@ ccscs[0-9])
     if [[ ${extra_params} ]]; then
         case $extra_params in
         none)  extra_params=""; epdash="" ;;
-        coverage | fulldiagnostics | nr | perfbench | bounds_checking ) # known, continue
+        bounds_checking | coverage | fulldiagnostics | nr | perfbench | valgrind ) # known, continue
         ;;
         gcc530 | clang | gcc610 ) # known, continue
         ;;
@@ -236,7 +236,7 @@ darwin*)
     if [[ ${extra_params} ]]; then
         case $extra_params in
         none)  extra_params=""; epdash="" ;;
-        cuda | fulldiagnostics | nr | perfbench ) # known, continue
+        cuda | fulldiagnostics | nr | perfbench | valgrind ) # known, continue
         ;;
         *) echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
            print_use; exit 1 ;;


### PR DESCRIPTION
+ Use option `-e valgrind` to trigger a Dynamic Analysis dashboard entry.
+ Default all regression runs to Experimental builds. The crontab explicitly set the dashboard type to Nightly.
+ fixes losalamos/draco#53
+ fixes losalamos/draco#52
