### PR TITLE
Global key bindings for clang-format through emacs (from KT).

### DIFF
--- a/environment/elisp/draco-global-keys.el
+++ b/environment/elisp/draco-global-keys.el
@@ -10,6 +10,11 @@
 ;; Usage: (require 'draco-global-keys)
 ;; ======================================================================
 
+;; Clang-format
+(require 'clang-format)
+(global-set-key [(f12)] 'clang-format-region) ;; Windows/Linux
+(global-set-key [(C-M-tab)] 'clang-format-region) ;; Mac/Linux
+
 ;; Kill default XEmacs key binding annoyances:
 
 (define-key global-map "\C-x\C-k" 'kill-buffer)


### PR DESCRIPTION
+ Add lines to draco-global-keys.el to use clang-format with
  f12 key binding for Windows and C-M-tab binding for Mac