### PR TITLE
Fix a bug that prevented testing the most up-to-date version of a PR.

### DIFF
--- a/regression/fetch_co.sh
+++ b/regression/fetch_co.sh
@@ -9,18 +9,33 @@ GIT=$1
 githost=$2
 featurebranch=$3
 
+echo "This is fetch_co.log"
+echo "This is fetch_co.log" > fetch_co.log
+
+function log()
+{
+  echo "$1"
+  echo "$1" >> fetch_co.log
+}
+function run()
+{
+  echo "$1"
+  echo "$1" >> fetch_co.log
+  eval $1 >> fetch_co.log
+}
+
 if ! test -x $GIT; then
-   echo "FATAL ERROR: unable to run GIT=$GIT."
+   log "FATAL ERROR: unable to run GIT=$GIT."
    exit 1
 fi
 if [[ ! ${githost} ]]; then
-   echo "FATAL ERROR: exected three arguments, example: fetch_co.sh <path to git> <github> <42>"
-   echo "     second argument should be 'github' or 'gitlab'"
+   log "FATAL ERROR: exected three arguments, example: fetch_co.sh <path to git> <github> <42>"
+   log "     second argument should be 'github' or 'gitlab'"
    exit 1
 fi
 if [[ ! ${featurebranch} ]]; then
-   echo "FATAL ERROR: exected three arguments, example: fetch_co.sh <path to git> <github> <42>"
-   echo "     third argument should be a bare integer (the pull request number)."
+   log "FATAL ERROR: exected three arguments, example: fetch_co.sh <path to git> <github> <42>"
+   log "     third argument should be a bare integer (the pull request number)."
    exit 1
 fi
 
@@ -30,10 +45,13 @@ else
   prdir="merge-requests"
 fi
 
-cmd="${GIT} fetch origin ${prdir}/${featurebranch}/head:pr${featurebranch}"
-echo $cmd
-eval $cmd
+# Use different logic if the desired featurebranch is already checked out.
+thisbranch=`git rev-parse --abbrev-ref HEAD`
+log "thisbranch = $thisbranch"
 
-cmd="${GIT} checkout pr${featurebranch}"
-echo $cmd
-eval $cmd
+if test "$thisbranch" = "pr${featurebranch}"; then
+  run "${GIT} pull origin pull/${featurebranch}/head"
+else
+  run "${GIT} fetch origin ${prdir}/${featurebranch}/head:pr${featurebranch}"
+  run "${GIT} checkout pr${featurebranch}"
+fi


### PR DESCRIPTION
+ If the regression system (draco/regression/regression-master.sh) is used to test a pull request, it might not test to most up-to-date version of the PR due to an improper git pull command.
+ This change updates the script so that it saves some debug information to a log file.
+ This change also checks to see if the current PR is already cloned and checked out. If it is, then use `git pull origin pull/#/head` instead of a bare `git pull.` This ensures that the most recent version of the PR is downloaded from github before the regressions are performed.