### PR TITLE
Patch indentation in draco mode for emacs (very minor).

### DIFF
--- a/environment/elisp/draco-config-modes.el
+++ b/environment/elisp/draco-config-modes.el
@@ -284,7 +284,7 @@ parameters on creation of buffers managed by cc-mode.el for Nix's personal codin
 	 "draco" '
 	 (
           ; Tab indent == 2 spaces
-	  (c-basic-offset 2)
+	  (c-basic-offset . 2)
           ; Snap #s to the first column
 	  (c-electric-pound-behavior . 'alignleft)
           ; Regexp to find the starting brace of a block


### PR DESCRIPTION
This is a minor change to one line in elisp file draco-config-modes.el to appropriately tab in emacs.