### PR TITLE
Use better logic to determine if R123_USE_CXX11=1 should be used.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -69,12 +69,6 @@ endif()
 configure_file( draco-config-install.cmake.in
    ${Draco_BINARY_DIR}/CMakeFiles/draco-config.cmake @ONLY)
 
-# For Knights corner systems, also install the unit test driver
-if( HAVE_MIC AND  EXISTS ${Draco_BINARY_DIR}/config/run_test_on_mic.sh )
-  install( PROGRAMS ${Draco_BINARY_DIR}/config/run_test_on_mic.sh
-    DESTINATION cmake/draco )
-endif()
-
 # Install scripts and macros to make them available by other projects.
 set( file_list ${CMake_src} ${CMake_in} ${Draco_BINARY_DIR}/CMakeFiles/draco-config.cmake )
 

--- a/src/rng/CMakeLists.txt
+++ b/src/rng/CMakeLists.txt
@@ -14,12 +14,12 @@ project( rng CXX )
 # ---------------------------------------------------------------------------- #
 # default to using C++11 features of Random123.
 set( R123_USE_CXX11 1 )
-# if the current compiler doesn't support some c++11 features, disable 
+# if the current compiler doesn't support some c++11 features, disable
 # Random123's use of these extensions.
 set( required_features "cxx_explicit_conversions;cxx_static_assert;cxx_unrestricted_unions;cxx_long_long_type;cxx_constexpr;cxx_type_traits")
 foreach( feature ${required_features} )
    list( FIND CXX11_FEATURE_LIST ${feature} featurefound )
-   if( ${feature} STREQUAL "-1" )
+   if( ${featurefound} STREQUAL "-1" )
       unset(R123_USE_CXX11)
    endif()
 endforeach()
@@ -30,9 +30,9 @@ if( USE_CUDA OR WIN32 )
    unset(R123_USE_CXX11)
 endif()
 
-# At least one report that Intel/15 doesn't work correctly with Random123 with 
+# At least one report that Intel/15 doesn't work correctly with Random123 with
 # c++11 features active.
-# if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" AND 
+# if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" AND
     # ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 16.0 )
    # unset(R123_USE_CXX11)
 # endif()

--- a/src/rng/CMakeLists.txt
+++ b/src/rng/CMakeLists.txt
@@ -12,17 +12,31 @@ project( rng CXX )
 # ---------------------------------------------------------------------------- #
 # Generate config.h (only occurs when cmake is run)
 # ---------------------------------------------------------------------------- #
+# default to using C++11 features of Random123.
+set( R123_USE_CXX11 1 )
+# if the current compiler doesn't support some c++11 features, disable 
+# Random123's use of these extensions.
+set( required_features "cxx_explicit_conversions;cxx_static_assert;cxx_unrestricted_unions;cxx_long_long_type;cxx_constexpr;cxx_type_traits")
+foreach( feature ${required_features} )
+   list( FIND CXX11_FEATURE_LIST ${feature} featurefound )
+   if( ${feature} STREQUAL "-1" )
+      unset(R123_USE_CXX11)
+   endif()
+endforeach()
 
-# Random123 with C++11 requries
-# - HAS_CXX11_EXPLICIT_CONVERSION 
-# - HAS_CXX11_STATIC_ASSERT 
-# - HAS_CXX11_TYPE_TRAITS 
-# - HAS_CXX11_UNRESTRICTED_UNIONS
-# - HAS_CXX11_LONG_LONG 
-# - HAS_CXX11_CONSTEXPR
-if( NOT USE_CUDA )
-   set( R123_USE_CXX11 1 )
+# When also linking to CUDA, C++11 doesn't work.
+# MSVC 2013 RTM doesn't provide constexpr, even though cmake thinks it does.
+if( USE_CUDA OR WIN32 )
+   unset(R123_USE_CXX11)
 endif()
+
+# At least one report that Intel/15 doesn't work correctly with Random123 with 
+# c++11 features active.
+# if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" AND 
+    # ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 16.0 )
+   # unset(R123_USE_CXX11)
+# endif()
+
 configure_file( config.h.in ${PROJECT_BINARY_DIR}/rng/config.h )
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
* Disable for `USE_CUDA=ON`
* Disable for Win32 (MSVC 2013 doesn't like it - this pr should fix the 43 compile failures reported by [cdash](rtt.lanl.gov/cdash/index.php?project=Draco&date=2016-09-27))
* Check the features provided by the current compiler before turning this option on
* Retire some build system logic related to KNC.

* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] Valgrind test passes
  * [x] Toss2 checks pass
  * [x] Trinitite checks pass
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
