### PR TITLE
Minor tweaks after vendor-dir changes on ccs-net servers.

### DIFF
--- a/environment/bashrc/.bashrc_linux64
+++ b/environment/bashrc/.bashrc_linux64
@@ -36,7 +36,7 @@ ccscs[1-9]*)
     fi
     module load user_contrib
     export dracomodules="gcc/4.8.5 openmpi cmake \
-lapack random123 eospac gsl dracoscripts subversion ndi python/2.7.11
+lapack random123 eospac gsl dracoscripts subversion ndi python
 metis parmetis superlu-dist trilinos git"
     ;;
 ccsnet3*)
@@ -45,7 +45,7 @@ ccsnet3*)
       export VENDOR_DIR=/scratch/vendors
     fi
     module load user_contrib
-    export dracomodules="dracoscripts subversion python/2.7.11 git"
+    export dracomodules="dracoscripts subversion python git"
     ;;
 *)
     # Locate the vendor directory

--- a/regression/valgrind_suppress.txt
+++ b/regression/valgrind_suppress.txt
@@ -123,6 +123,16 @@
    ...
 }
 {
+  <pmpi_init_thread-6>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:df_search
+   ...
+   fun:PMPI_INIT
+   ...
+}
+{
   <clone-2>
    Memcheck:Leak
    match-leak-kinds: definite


### PR DESCRIPTION
+ Add another valgrind suppression for openmpi (new for 1.10.3).
+ Do not specify the python version to load from the default `.bashrc_linux64`. Use a `.modulerc` file instead.
  
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Valgrind test passes
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
