### PR TITLE
Fix bounds-checking regression and provide sync_vendors script.

### DIFF
--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -1,7 +1,7 @@
 # crontab for ccscs7
 
 # Keep vendor installations in sync between ccs-net servers.
-45 21 * * 0-6 /home/kellyt/bin/sync_vendors.sh &> /ccs/codes/radtran/vendors/logs/sync_vendors_ccscs7.log
+45 21 * * 0-6 /scratch/regress/draco/regression/sync_vendors.sh &> /scratch/regress/logs/sync_vendors_ccscs.log
 
 # Update the regression scripts.
 01 22 * * 0-6 /scratch/regress/draco/regression/update_regression_scripts.sh &> /scratch/regress/logs/update_regression_scripts.log

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -124,7 +124,7 @@ bounds_checking)
   fi
   bounds_checking=on
   run "module swap superlu-dist superlu-dist/4.3-bc"
-  run "module swap trilinos trilinos/12.6.1-bc"
+  run "module swap trilinos trilinos/12.8.1-bc"
   run "module swap metis metis/5.1.0-bc"
   run "module swap parmetis parmetis/4.0.3-bc"
   ;;

--- a/regression/sync_vendors.sh
+++ b/regression/sync_vendors.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Run from ccscs7:
+#   - Mirror ccscs7:/scratch/vendors -> /ccs/codes/radtran/vendors/rhel72
+#     Do not mirror the ndi directory (300+ GB)
+#   - Mirror ccscs7:/scratch/vendors  -> ccscs[234568]:/scratch/vendors
+
+function run ()
+{
+    echo $1;
+    if ! [ $dry_run ]; then
+        eval $1;
+    fi
+}
+
+machine=`uname -n`
+vdir=/scratch/vendors
+r72v=/ccs/codes/radtran/vendors/rhel72vendors
+ccs_servers="2 3 4 5 6 7 8"
+
+echo "Rsync vendor directory to /ccs/codes/radtran/vendors and to"
+echo "/scratch/vendors on:"
+for m in $ccs_servers; do echo " - ccscs${m}"; done
+
+# make a backup copy of vendors to $r72v
+
+if ! test -d $vdir; then
+  echo "Source directory $vdir is missing."
+  exit 1
+fi
+
+#cd $vdir
+#find . -name '*~' -exec echo rm -f {} \;
+echo " "
+echo "Clean up permissions on source files..."
+run "chgrp -R draco $vdir"
+run "chmod -R g+rwX,o=g-w $vdir"
+
+echo " "
+echo "Save a copy on /ccs/codes/radtran..."
+run "rsync -av --exclude 'ndi' --delete $vdir/ $r72v"
+# -vaum
+
+# rsync vendors ccscs7 -> other machines.
+# limit network to 50 MB/sec (400 mbps)
+echo " "
+echo "Rsync $vdir to other ccs-net servers... "
+for m in $ccs_servers; do
+  if test `uname -n | grep $m | wc -l` = 0; then
+    case $m in
+      5)
+        # do not copy ndi, not enough space
+        run "rsync -av --exclude ndi --delete --bwlimit=50000 $vdir/ ccscs${m}:$vdir"
+        ;;
+      *)
+        run "rsync -av --delete --bwlimit=50000 $vdir/ ccscs${m}:$vdir"
+        # -vaum
+        ;;
+    esac
+  fi
+done
+
+echo " "
+echo "done"
+
+# Rsync directories
+# cd $mastervdir
+# dirs=`\ls -1 $mastervdir`
+# for dir in $dirs; do
+#     shortdir=`echo $dir | sed -e 's/-.*//'`
+
+#     case $shortdir in
+#     modules* | Modules* | deprecated | environment | sources | win32 )
+#        # do not process
+#        ;;
+#     emacs* )
+#        # do not process
+#        ;;
+#     *)
+#        echo " "
+#        echo "cd $masterdir"
+#        echo "rsync -vaum $dir ${VENDOR_DIR}"
+#        rsync -vaum $dir ${VENDOR_DIR}
+#        ;;
+#     esac
+# done
+
+# chgrp -R draco ${VENDOR_DIR}
+# chmod -R g+rwX,o=g-w ${VENDOR_DIR}


### PR DESCRIPTION
+ The gcc-4.8.5 Debug regression on ccscs7 enables bounds-checking in the STL. Update the list of modulefiles loaded to allow this regression to work correctly with trilinos-12.8.1.
+ Provide a script that is run by cron, that will push the ccscs7 vendor directory to all other ccs-net machines nightly.
  
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
  
