### PR TITLE
On Toss2 systems, begin using openmpi/1.10.3 and trilinos/12.8.1.

### DIFF
--- a/environment/bashrc/.bashrc_toss22
+++ b/environment/bashrc/.bashrc_toss22
@@ -53,7 +53,7 @@ else
   fi
   module load friendly-testing
 
-  export dracomodules="intel/16.0.3 openmpi/1.10.1 mkl trilinos/12.6.1 \
+  export dracomodules="intel/16.0.3 openmpi/1.10.3 mkl trilinos/12.8.1 \
 superlu-dist/4.3 metis/5.1.0 parmetis/4.0.3 ndi random123 eospac/6.2.4 \
 subversion cmake/3.6.0 numdiff git totalview emacs grace"
 

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -95,11 +95,11 @@ unset _LMFILES_
 run "module list"
 run "module load user_contrib"
 run "module load friendly-testing"
-run "module load cmake/3.6.0"
+run "module load cmake/3.6.2"
 run "module load intel/16.0.3"
-run "module load openmpi/1.10.1"
+run "module load openmpi/1.10.3"
 run "module load mkl"
-run "module load trilinos/12.6.1"
+run "module load trilinos/12.8.1"
 run "module load superlu-dist"
 run "module load metis"
 run "module load parmetis"
@@ -148,7 +148,7 @@ pgi)
     run "module unload superlu-dist trilinos"
     run "module unload mkl openmpi intel"
     run "module list"
-    run "module load pgi/16.4 openmpi/1.10.1"
+    run "module load pgi/16.4 openmpi/1.10.3"
     export TMPDIR=/usr/projects/jayenne/regress/tmp
     comp="pgCC"
     CXX=`which pgCC`


### PR DESCRIPTION
+ Openmpi/1.10.1 has been removed from toss2 systems.
+ Vendors have been built with openmpi/1.10.3.
+ Increment trilinos to 12.8.1 (since I needed to build it from scratch to work with openmpi/1.10.3.)
  
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Toss2 checks pass
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
  
