### PR TITLE
Reduce memory reserved for aprun/mapn to support KNL.

### DIFF
--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -271,10 +271,10 @@ macro( setupCrayMPI )
   query_topology()
 
   # Extra flags for OpenMP + MPI
-  # -m 2g reserves 2GB per core when running with MAPN.
+  # -m 1400m reserves 1.4 GB per core when running with MAPN.
   # Trinitite/Trinity has 4GB/node for haswells
   if( DEFINED ENV{OMP_NUM_THREADS} )
-    set( MPIEXEC_OMP_POSTFLAGS "-q -b -m 2g -d $ENV{OMP_NUM_THREADS}" CACHE
+    set( MPIEXEC_OMP_POSTFLAGS "-q -b -m 1400m -d $ENV{OMP_NUM_THREADS}" CACHE
       STRING "extra mpirun flags (list)." FORCE)
   else()
     message( STATUS "
@@ -285,8 +285,8 @@ WARNING: ENV{OMP_NUM_THREADS} is not set in your environment,
   # -b        Bypass transfer of application executable to the compute node.
   # -cc none  Do not bind threads to a CPU within the assigned NUMA node.
   # -q        Quiet
-  # -m 2g     Reserve 2 GB of RAM per PE.
-  set( MPIEXEC_POSTFLAGS "-q -b -m 2g" CACHE STRING
+  # -m 1400m     Reserve 1.4 GB of RAM per PE.
+  set( MPIEXEC_POSTFLAGS "-q -b -m 1400m" CACHE STRING
     "extra mpirun flags (list)." FORCE)
 
 endmacro()

--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -85,17 +85,6 @@ if( NOT CRAY_PE )
 endif()
 toggle_compiler_flag( OPENMP_FOUND ${OpenMP_C_FLAGS} "C;CXX" "" )
 
-#
-# Sanity checks
-#
-
-# On Moonlight, Intel-16 requires MKL-11.3
-if( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 15.1 AND DEFINED ENV{MKLROOT} )
-  if( NOT $ENV{MKLROOT} MATCHES "2016" )
-    message( FATAL_ERROR "Intel-16 requires MKL-11.3+.")
-  endif()
-endif()
-
 #------------------------------------------------------------------------------#
 # End config/unix-intel.cmake
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
* When packing multiple tests onto a Cray node, we must reserve memory for each PE.  I originally set this to 2 GB.  This value is too high for the KNL partition and would oversubscribe the node's memory. This PR reduces the value to 1.4 GB/PE.
* This commit also removes on obsolete check that ensures that MKL is new enough for the selected Intel compiler.  Newer modulefiles for Intel compilers automatically select the MKL version so this check is no longer needed. 
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Toss2 checks pass
  * [x] Trinitite checks pass
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
  

