### PR TITLE
Provide better support for DRACO_C4=SCALAR.

### DIFF
--- a/src/VendorChecks/CMakeLists.txt
+++ b/src/VendorChecks/CMakeLists.txt
@@ -10,6 +10,9 @@ cmake_minimum_required(VERSION 3.0.0)
 project( VendorsChecks CXX )
 
 # This component only has tests.
+
+# Ignore these tests if we are building on Windows or if we aren't building the
+# unit tests.
 if( NOT WIN32 )
   if( BUILD_TESTING )
     add_subdirectory(test)

--- a/src/VendorChecks/test/CMakeLists.txt
+++ b/src/VendorChecks/test/CMakeLists.txt
@@ -29,20 +29,26 @@ if( METIS_FOUND )
     )
 endif()
 
-if( ParMETIS_FOUND )
-add_parallel_tests(
-   SOURCES "tstParmetis.cc"
-   DEPS    "Lib_c4;ParMETIS::parmetis"
-   PE_LIST "3"
-   )
-endif()
+# Only run these tests if MPI is found and enabled. Both parmetis and
+# superlu-dist require MPI.
+if( ${DRACO_C4} STREQUAL "MPI" )
 
-if( SuperLU_DIST_FOUND )
-  add_parallel_tests(
-    SOURCES "tstSuperludist.cc"
-    DEPS    "Lib_c4;SuperLU_DIST::superludist;ParMETIS::parmetis;lapack"
-    PE_LIST "4"
-    )
+  if( ParMETIS_FOUND )
+    add_parallel_tests(
+      SOURCES "tstParmetis.cc"
+      DEPS    "Lib_c4;ParMETIS::parmetis"
+      PE_LIST "3"
+      )
+  endif()
+
+  if( SuperLU_DIST_FOUND )
+    add_parallel_tests(
+      SOURCES "tstSuperludist.cc"
+      DEPS    "Lib_c4;SuperLU_DIST::superludist;ParMETIS::parmetis;lapack"
+      PE_LIST "4"
+      )
+  endif()
+
 endif()
 
 # ---------------------------------------------------------------------------- #

--- a/src/c4/config.h.in
+++ b/src/c4/config.h.in
@@ -1,10 +1,9 @@
 /*-----------------------------------*-C-*-----------------------------------*/
-/* config.h */
-/* Thomas M. Evans */
-/* Fri Jan  8 14:54:44 1999 */
-/* Defines necessary for the C4 package   */
-/*---------------------------------------------------------------------------*/
-/* $Id$ */
+/* config.h
+ * Thomas M. Evans
+ * Fri Jan  8 14:54:44 1999
+ * Defines necessary for the C4 package
+ * Copyright (C) 2016 Los Alamos National Security, all rights reserved. */
 /*---------------------------------------------------------------------------*/
 
 #ifndef rtt_c4_config_h


### PR DESCRIPTION
+ Only test parmetis and superlu-dist libraries if current build links to MPI.
+ Clean up the comment block in `c4/config.h`.
  
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] Valgrind test passes
  * [x] Toss2 checks pass
  * [x] Trinitite checks pass
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation