### PR TITLE
Fix a bug in the regression script that is used to checkout PRs.

### DIFF
--- a/regression/fetch_co.sh
+++ b/regression/fetch_co.sh
@@ -50,7 +50,7 @@ thisbranch=`git rev-parse --abbrev-ref HEAD`
 log "thisbranch = $thisbranch"
 
 if test "$thisbranch" = "pr${featurebranch}"; then
-  run "${GIT} pull origin pull/${featurebranch}/head"
+  run "${GIT} pull origin $prdir/${featurebranch}/head"
 else
   run "${GIT} fetch origin ${prdir}/${featurebranch}/head:pr${featurebranch}"
   run "${GIT} checkout pr${featurebranch}"


### PR DESCRIPTION
* For gitlab-based repositories (jayenne), if a PR was updated after the initial regression tests were run, the `fetch_co.sh` script would fail to update the checked-out source directory due to a bug in the script.  The bug was a hard coded path to `pull/[0-9]+/head` that works for github, but not gitlab. the command should have used `$prdir/[0-9]/head`.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Toss2 checks pass
  * [x] Trinitite checks pass
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
  

