### PR TITLE
Teach the regression-system to run a 'belosmods' flavor.

### DIFF
--- a/regression/ccscs-crontab
+++ b/regression/ccscs-crontab
@@ -1,7 +1,7 @@
 # crontab for ccscs7
 
 # Keep vendor installations in sync between ccs-net servers.
-45 21 * * 0-6 /scratch/regress/draco/regression/sync_vendors.sh &> /scratch/regress/logs/sync_vendors_ccscs.log
+45 21 * * 0-6 /scratch/regress/draco/regression/sync_vendors.sh &> /scratch/regress/logs/sync_vendors_ccscs7.log
 
 # Update the regression scripts.
 01 22 * * 0-6 /scratch/regress/draco/regression/update_regression_scripts.sh &> /scratch/regress/logs/update_regression_scripts.log
@@ -32,20 +32,26 @@
 
 00 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e bounds_checking &> /scratch/regress/logs/ccscs-Debug-master-bounds_checking.log
 
-00 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e valgrind &> /scratch/regress/logs/ccscs-Debug-master-valgrind.log
+30 02 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e valgrind &> /scratch/regress/logs/ccscs-Debug-master-valgrind.log
 
 #------------------------------------------------------------------------------#
 # Clang-3.8.0, gcc-5.3.0, gcc-6.1.0
 #------------------------------------------------------------------------------#
 
-00 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e clang &> /scratch/regress/logs/ccscs-Debug-clang-master.log
+00 03 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e clang &> /scratch/regress/logs/ccscs-Debug-clang-master.log
 
-00 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc530 &> /scratch/regress/logs/ccscs-Debug-gcc530-master.log
+00 04 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc530 &> /scratch/regress/logs/ccscs-Debug-gcc530-master.log
 
-00 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc610 &> /scratch/regress/logs/ccscs-Debug-gcc610-master.log
+00 05 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco jayenne capsaicin" -e gcc610 &> /scratch/regress/logs/ccscs-Debug-gcc610-master.log
 
 #------------------------------------------------------------------------------#
-# Special build for a Pull Request that is under consideration
+# Additional special regressions
+#------------------------------------------------------------------------------#
+
+00 06 * * 0-6 /scratch/regress/draco/regression/regression-master.sh -r -b Debug -d Nightly -p "draco capsaicin" -e belosmods &> /scratch/regress/logs/ccscs-Debug-belosmods.log
+
+#------------------------------------------------------------------------------#
+# Example for running a regression for a PR that is under consideration
 #------------------------------------------------------------------------------#
 
 # Build both draco and jayenne from PRs.

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -116,6 +116,12 @@ coverage)
   CXX=`which g++`
   CC=`which gcc`
   ;;
+belosmods)
+  echo "Use special version of Trilinos (pr539)"
+  run "module swap trilinos trilinos/12.8.1-belosmods"
+  comp=$comp-belosmods
+  buildname_append="-belosmods"
+  ;;
 bounds_checking)
   echo "Bounds checking option selected."
   if ! test "${build_type}" == "Debug"; then
@@ -252,13 +258,17 @@ elif test "${subproj}" == asterisk; then
     script_name=Asterisk_Linux64.cmake
 fi
 
+# Append the username to the build name unless option '-r' is specified.
 if test "${regress_mode}" = "off"; then
+  if [[ ${buildname_append} ]]; then
+    export buildname_append="-${USER}${buildname_append}"
+  else
     export buildname_append="-${USER}"
+ fi
 fi
 
 if test "${regress_mode}" = "off"; then
     export work_dir=${base_dir}/cdash/${subproj}/${dashboard_type}_${comp}/${build_type}
-    export buildname_append="-${USER}"
     export AUTODOCDIR=$work_dir/autodoc
 else
     export work_dir=${base_dir}/${subproj}/${dashboard_type}_${comp}/${build_type}

--- a/regression/ccscs-regress.msub
+++ b/regression/ccscs-regress.msub
@@ -14,24 +14,24 @@
 # Sanity Check
 # ----------------------------------------
 if [[ ! ${subproj} ]]; then
-   echo "Fatal Error, subproj not found in environment."
-   exit 1
+  echo "Fatal Error, subproj not found in environment."
+  exit 1
 fi
 if [[ ! ${regdir} ]]; then
-   echo "Fatal Error, regdir not found in environment."
-   exit 1
+  echo "Fatal Error, regdir not found in environment."
+  exit 1
 fi
 if [[ ! ${rscriptdir} ]]; then
-   echo "Fatal Error, rscriptdir not found in environment."
-   exit 1
+  echo "Fatal Error, rscriptdir not found in environment."
+  exit 1
 fi
 if [[ ! ${build_type} ]]; then
-   echo "Fatal Error, build_type not found in environment."
-   exit 1
+  echo "Fatal Error, build_type not found in environment."
+  exit 1
 fi
 if [[ ! ${logdir} ]]; then
-   echo "Fatal Error, logdir not found in environment."
-   exit 1
+  echo "Fatal Error, logdir not found in environment."
+  exit 1
 fi
 
 # Environment setup
@@ -55,13 +55,13 @@ export GIT_SSL_NO_VERIFY=true
 source $rscriptdir/scripts/common.sh
 
 case $REGRESSION_PHASE in
-cbt)
+  cbt)
     ctestparts=Configure,Build,Test
     if test "${build_autodoc:-off}" == "on"; then
       ctestparts="${ctestparts},Autodoc"
     fi
     ;;
-s)
+  s)
     ctestparts=Submit
     # Submitting to CDash requires this
     unset http_proxy
@@ -101,64 +101,64 @@ run "module load doxygen graphviz" # qt
 comp=gcc
 
 case $extra_params in
-"")
-  # no-op
-  ;;
-coverage)
-  # comp=gcc-5.2.0
-  echo "Coverage option selected."
-  if ! test "${build_type}" == "Debug"; then
-    echo "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
-    exit 1
-  fi
-  build_type=Coverage
-  run "module load bullseyecoverage"
-  CXX=`which g++`
-  CC=`which gcc`
-  ;;
-belosmods)
-  echo "Use special version of Trilinos (pr539)"
-  run "module swap trilinos trilinos/12.8.1-belosmods"
-  comp=$comp-belosmods
-  buildname_append="-belosmods"
-  ;;
-bounds_checking)
-  echo "Bounds checking option selected."
-  if ! test "${build_type}" == "Debug"; then
-    echo "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
-    exit 1
-  fi
-  bounds_checking=on
-  run "module swap superlu-dist superlu-dist/4.3-bc"
-  run "module swap trilinos trilinos/12.8.1-bc"
-  run "module swap metis metis/5.1.0-bc"
-  run "module swap parmetis parmetis/4.0.3-bc"
-  ;;
-clang)
-  run "module purge"
-  run "module load user_contrib"
-  run "module load llvm openmpi cmake"
-  run "module load dracoscripts subversion random123"
-  run "module load lapack gsl" # eospac
-  run "module load superlu-dist/4.3"
-  run "module load ndi metis parmetis trilinos"
-  run "module load graphviz"
-  comp=clang
-  ;;
-fulldiagnostics)
-  comp="intel-fulldiagnostics"
-  ;;
-gcc530)
-  run "module purge"
-  run "module load user_contrib"
-  run "module load gcc/5.3.0 openmpi cmake"
-  run "module load dracoscripts subversion random123"
-  run "module load lapack gsl eospac"
-  run "module load superlu-dist"
-  run "module load ndi metis parmetis trilinos"
-  comp=gcc-5.3.0
-  ;;
-gcc610)
+  "")
+    # no-op
+    ;;
+  coverage)
+    # comp=gcc-5.2.0
+    echo "Coverage option selected."
+    if ! test "${build_type}" == "Debug"; then
+      echo "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
+      exit 1
+    fi
+    build_type=Coverage
+    run "module load bullseyecoverage"
+    CXX=`which g++`
+    CC=`which gcc`
+    ;;
+  belosmods)
+    echo "Use special version of Trilinos (pr539)"
+    run "module swap trilinos trilinos/12.8.1-belosmods"
+    comp=$comp-belosmods
+    export buildname_append="-belosmods"
+    ;;
+  bounds_checking)
+    echo "Bounds checking option selected."
+    if ! test "${build_type}" == "Debug"; then
+      echo "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
+      exit 1
+    fi
+    bounds_checking=on
+    run "module swap superlu-dist superlu-dist/4.3-bc"
+    run "module swap trilinos trilinos/12.8.1-bc"
+    run "module swap metis metis/5.1.0-bc"
+    run "module swap parmetis parmetis/4.0.3-bc"
+    ;;
+  clang)
+    run "module purge"
+    run "module load user_contrib"
+    run "module load llvm openmpi cmake"
+    run "module load dracoscripts subversion random123"
+    run "module load lapack gsl" # eospac
+    run "module load superlu-dist/4.3"
+    run "module load ndi metis parmetis trilinos"
+    run "module load graphviz"
+    comp=clang
+    ;;
+  fulldiagnostics)
+    comp="intel-fulldiagnostics"
+    ;;
+  gcc530)
+    run "module purge"
+    run "module load user_contrib"
+    run "module load gcc/5.3.0 openmpi cmake"
+    run "module load dracoscripts subversion random123"
+    run "module load lapack gsl eospac"
+    run "module load superlu-dist"
+    run "module load ndi metis parmetis trilinos"
+    comp=gcc-5.3.0
+    ;;
+  gcc610)
     run "module purge"
     run "module load user_contrib"
     run "module load gcc/6.1.0 openmpi cmake"
@@ -167,16 +167,16 @@ gcc610)
     run "module load superlu-dist"
     run "module load ndi metis parmetis trilinos"
     comp=gcc-6.1.0
-  ;;
-valgrind)
-  echo "Dynamic Analysis (valgrind) option selected."
-  if ! test "${build_type}" == "Debug"; then
-    echo "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
-    exit 1
-  fi
-  build_type=DynamicAnalysis
-  ;;
-*)
+    ;;
+  valgrind)
+    echo "Dynamic Analysis (valgrind) option selected."
+    if ! test "${build_type}" == "Debug"; then
+      echo "FATAL ERROR: build_type (-b) must be Debug when using extra option (-e) coverage."
+      exit 1
+    fi
+    build_type=DynamicAnalysis
+    ;;
+  *)
     echo "FATAL ERROR"
     echo "Extra parameter = ${extra_param} requested but is unknown to"
     echo "the regression system."
@@ -218,20 +218,20 @@ fi
 # Build type     : Release, Debug, Coverage
 
 if [[ ! ${dashboard_type} ]]; then
-   dashboard_type=Experimental
+  dashboard_type=Experimental
 fi
 if [[ ! ${base_dir} ]]; then
-   if test "${regress_mode}" = "off"; then
-      moniker=`whoami`
-      base_dir=/scratch/${moniker}
-   else
-      base_dir=/scratch/regress/cdash
-   fi
-   mkdir -p $base_dir
-   if ! test -d ${base_dir}; then
-      echo "Fatal Error, base_dir=${base_dir} not found in environment."
-      exit 1
-   fi
+  if test "${regress_mode}" = "off"; then
+    moniker=`whoami`
+    base_dir=/scratch/${moniker}
+  else
+    base_dir=/scratch/regress/cdash
+  fi
+  mkdir -p $base_dir
+  if ! test -d ${base_dir}; then
+    echo "Fatal Error, base_dir=${base_dir} not found in environment."
+    exit 1
+  fi
 fi
 
 echo " "
@@ -245,70 +245,68 @@ echo "ccscs-regress.msub: comp           = $comp"
 #----------------------------------------------------------------------#
 
 if test "${subproj}" == draco; then
-    script_dir=${rscriptdir}
-    script_name=Draco_Linux64.cmake
+  script_dir=${rscriptdir}
+  script_name=Draco_Linux64.cmake
 elif test "${subproj}" == jayenne; then
-    script_dir=`echo ${rscriptdir} | sed -e 's/draco/jayenne/'`
-    script_name=Jayenne_Linux64.cmake
+  script_dir=`echo ${rscriptdir} | sed -e 's/draco/jayenne/'`
+  script_name=Jayenne_Linux64.cmake
 elif test "${subproj}" == capsaicin; then
-    script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%capsaicin/scripts%'`
-    script_name=Capsaicin_Linux64.cmake
+  script_dir=`echo ${rscriptdir} | sed -e 's%draco/regression%capsaicin/scripts%'`
+  script_name=Capsaicin_Linux64.cmake
 elif test "${subproj}" == asterisk; then
-    script_dir=`echo ${rscriptdir} | sed -e 's/draco/asterisk/'`
-    script_name=Asterisk_Linux64.cmake
+  script_dir=`echo ${rscriptdir} | sed -e 's/draco/asterisk/'`
+  script_name=Asterisk_Linux64.cmake
 fi
 
 # Append the username to the build name unless option '-r' is specified.
-if test "${regress_mode}" = "off"; then
+if [[ "${regress_mode}" = "off" ]]; then
   if [[ ${buildname_append} ]]; then
     export buildname_append="-${USER}${buildname_append}"
   else
     export buildname_append="-${USER}"
- fi
+  fi
+  export work_dir=${base_dir}/cdash/${subproj}/${dashboard_type}_${comp}/${build_type}
+  export AUTODOCDIR=$work_dir/autodoc
+else
+  export work_dir=${base_dir}/${subproj}/${dashboard_type}_${comp}/${build_type}
 fi
 
-if test "${regress_mode}" = "off"; then
-    export work_dir=${base_dir}/cdash/${subproj}/${dashboard_type}_${comp}/${build_type}
-    export AUTODOCDIR=$work_dir/autodoc
-else
-    export work_dir=${base_dir}/${subproj}/${dashboard_type}_${comp}/${build_type}
-fi
 echo "ccscs-regress.msub: work_dir       = ${work_dir}"
 echo " "
 setup_dirs=`echo $ctestparts | grep Configure`
 if [[ ${setup_dirs} ]]; then
-   if ! test -d ${work_dir}; then
-      /usr/bin/install -d ${work_dir}/source
-      /usr/bin/install -d ${work_dir}/build
-      /usr/bin/install -d ${work_dir}/target
-   else
-      if test -d ${work_dir}/target/lib; then
-         rm -rf ${work_dir}/target/*
-      fi
-      # empty the autodoc directory to force new build
-      if test -d ${word_dir}/build/autodoc; then
-         rm -rf ${word_dir}/build/autodoc/*
-      fi
-      # keep the purger from removing the source files.
-      # find ${work_dir}/source/ -exec touch {} \;
-   fi
+  if ! test -d ${work_dir}; then
+    /usr/bin/install -d ${work_dir}/source
+    /usr/bin/install -d ${work_dir}/build
+    /usr/bin/install -d ${work_dir}/target
+  else
+    if test -d ${work_dir}/target/lib; then
+      rm -rf ${work_dir}/target/*
+    fi
+    # empty the autodoc directory to force new build
+    if test -d ${word_dir}/build/autodoc; then
+      rm -rf ${word_dir}/build/autodoc/*
+    fi
+    # keep the purger from removing the source files.
+    # find ${work_dir}/source/ -exec touch {} \;
+  fi
 fi
 
 if test "${build_type}" = "Coverage"; then
-   # Coverage build imply Debug builds.
-   build_type="Debug,${build_type}"
-   run "export COVFILE=${work_dir}/build/CMake.cov"
-   if test -f ${COVFILE}; then
-      run "rm -f ${COVFILE}"
-      cov01 --on
-   fi
+  # Coverage build imply Debug builds.
+  build_type="Debug,${build_type}"
+  run "export COVFILE=${work_dir}/build/CMake.cov"
+  if test -f ${COVFILE}; then
+    run "rm -f ${COVFILE}"
+    cov01 --on
+  fi
 fi
 if test "${build_type}" = "DynamicAnalysis"; then
-   # DynamicAnalysis builds imply Debug builds.
-   build_type="Debug,${build_type}"
+  # DynamicAnalysis builds imply Debug builds.
+  build_type="Debug,${build_type}"
 fi
 if test "${bounds_checking:-off}" = "on"; then
-    build_type="${build_type},bounds_checking"
+  build_type="${build_type},bounds_checking"
 fi
 
 # Environment

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -747,12 +747,10 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
   # Assume that draco_work_dir is parallel to our current location, but only
   # replace the directory name preceeding the dashboard name.
   file( TO_CMAKE_PATH "$ENV{work_dir}" work_dir )
-  message("work_dir = ${work_dir}")
   string( REGEX REPLACE "${this_pkg}[/\\](Nightly|Experimental|Continuous)" "${dep_pkg}/\\1"
     ${dep_pkg}_work_dir ${work_dir} )
-  message("${dep_pkg}_work_dir = ${${dep_pkg}_work_dir}")
 
-  # If this is a coverage/nr build, link to the Debug/Release Draco files:
+  # If this is a special build, link to the normal Debug/Release Draco files:
   if( "${dep_pkg}" MATCHES "draco" )
     # coverage  build -> debug   version of Draco
     # nr        build -> release version of Draco
@@ -760,6 +758,7 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
     # string( REPLACE "Coverage" "Debug"  ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     string( REPLACE "intel-nr"        "icpc" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     string( REPLACE "intel-perfbench" "icpc" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
+    # string( REPLACE "-belosmods"      ""     ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
 
     if( "${this_pkg}" MATCHES "jayenne" )
       # If this is jayenne, we might be building a pull request. Replace the PR

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -382,7 +382,7 @@ macro( parse_args )
     endif()
   endif()
 
-  if( NOT "$ENV{buildname_append}x" STREQUAL "x" )
+  if( DEFINED ENV{buildname_append} )
     set( CTEST_BUILD_NAME "${CTEST_BUILD_NAME}$ENV{buildname_append}" )
   endif()
 

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -41,7 +41,7 @@ print_use()
     echo "         requires one string per project listed in option -p"
     echo "   -p    project names  = { draco, jayenne, capsaicin }"
     echo "                          This is a space delimited list within double quotes."
-    echo "   -e    extra params   = { none, clang, coverage, cuda, fulldiagnostics,"
+    echo "   -e    extra params   = { none, belosmods, clang, coverage, cuda, fulldiagnostics,"
     echo "                            knl, gcc530, gcc610, nr, perfbench, pgi, valgrind}"
     echo " "
     echo "Example:"
@@ -151,7 +151,7 @@ if [[ ${extra_params} ]]; then
    none)
       # if 'none' set to blank
       extra_params=""; epdash="" ;;
-   bounds_checking | clang | coverage | cuda | fulldiagnostics | knl | gcc530 )
+   belosmods | bounds_checking | clang | coverage | cuda | fulldiagnostics | knl | gcc530 )
       ;;
    gcc610 | nr | perfbench | pgi | valgrind )
       ;;
@@ -223,7 +223,7 @@ ccscs[0-9])
     if [[ ${extra_params} ]]; then
         case $extra_params in
         none)  extra_params=""; epdash="" ;;
-        bounds_checking | coverage | fulldiagnostics | nr | perfbench | valgrind ) # known, continue
+        belosmods | bounds_checking | coverage | fulldiagnostics | nr | perfbench | valgrind ) # known, continue
         ;;
         gcc530 | clang | gcc610 ) # known, continue
         ;;


### PR DESCRIPTION
+ Teach regression-master.sh about the option `-e belosmods`
+ Teach ccs-regress.msub about the `belosmods` option:
  - swap trilinos module with trilinos/12.8.1-belosmods
  - append `belosmods` to the build name that shows up on CDash.
+ refs #823
  
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] ccscs7 checks pass (normal regression system doesn't break)
  * [ ] Toss2 checks pass (normal regression system doesn't break)
  * [ ] Trinitite checks pass (normal regression system doesn't break)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
  * [x] Update ccs-crontab template