### PR TITLE
Improve Windows compatibility and file creation in Python application unit test driver

### DIFF
--- a/config/application_unit_test.py
+++ b/config/application_unit_test.py
@@ -279,14 +279,15 @@ class UnitTest:
       if (os.path.exists(self.draco_info)):
         # make a list of clean argument (no spaces, no empty strings)
         clean_draco_run_args = []
-        if self.run_cmd.strip():
-          clean_draco_run_args.append(self.run_cmd.strip())
+        for arg in self.run_cmd.split():
+          clean_draco_run_args.append(arg)
         if draco_info_numPE.strip():
           clean_draco_run_args.append(draco_info_numPE.strip())
         if self.draco_info.strip():
           clean_draco_run_args.append(self.draco_info.strip())
         clean_draco_run_args.append("--version")
 
+        print("About to run \'{0}\'".format(' '.join(clean_draco_run_args)))
         draco_process = \
           subprocess.Popen(clean_draco_run_args, stdout=subprocess.PIPE, \
           stderr=subprocess.STDOUT )
@@ -332,8 +333,8 @@ class UnitTest:
 
       # make a list of clean argument (no spaces, no empty strings)
       clean_run_args = []
-      if self.run_cmd.strip():
-        clean_run_args.append(self.run_cmd.strip())
+      for arg in self.run_cmd.split():
+        clean_run_args.append(arg)
       if draco_info_numPE.strip():
         clean_run_args.append(draco_info_numPE.strip())
       if self.app.strip():
@@ -488,8 +489,8 @@ class UnitTest:
 
       # make a list of clean argument (no spaces, no empty strings)
       clean_run_args = []
-      if numdiff_run_cmd.strip():
-        clean_run_args.append(numdiff_run_cmd.strip())
+      for arg in self.numdiff_run_cmd.split():
+        clean_run_args.append(arg)
       if self.numdiff_exe.strip():
         clean_run_args.append(self.numdiff_exe.strip())
       if self.outfile.strip():
@@ -569,8 +570,8 @@ class UnitTest:
 
       # make a list of clean argument (no spaces, no empty strings)
       clean_run_args = []
-      if diff_run_cmd.strip():
-        clean_run_args.append(diff_run_cmd.strip())
+      for arg in self.diff_run_cmd.split():
+        clean_run_args.append(arg)
       if diff_exe.strip():
         clean_run_args.append(diff_exe.strip())
       if path_1.strip():
@@ -641,8 +642,8 @@ class UnitTest:
 
       # make a list of clean argument (no spaces, no empty strings)
       clean_run_args = []
-      if diff_run_cmd.strip():
-        clean_run_args.append(diff_run_cmd.strip())
+      for arg in diff_run_cmd.split():
+        clean_run_args.append(arg)
       if gdiff_exe.strip():
         clean_run_args.append(gdiff_exe.strip())
       if gdiff_file.strip():

--- a/config/application_unit_test.py
+++ b/config/application_unit_test.py
@@ -335,8 +335,8 @@ class UnitTest:
       clean_run_args = []
       for arg in self.run_cmd.split():
         clean_run_args.append(arg)
-      if draco_info_numPE.strip():
-        clean_run_args.append(draco_info_numPE.strip())
+      if self.numPE.strip():
+        clean_run_args.append(self.numPE.strip())
       if self.app.strip():
         clean_run_args.append(self.app.strip())
       for arg in (self.arg_value.split()):
@@ -651,7 +651,10 @@ class UnitTest:
 
       # run diff command, redirecting stdout and stderr, get a unique
       # filename for the diff output and error files
+
+      print(clean_run_args)
       print("Running gdiff from {0} on {1}".format(gdiff_exe, gdiff_file))
+      print("About to run: {0}".format(" ".join(clean_run_args)))
       temp_diff_out = "diff_out_{0}".format(os.getpid())
       temp_diff_err = "diff_err_{0}".format(os.getpid())
       f_out = open(temp_diff_out, 'w')

--- a/config/application_unit_test.py
+++ b/config/application_unit_test.py
@@ -257,7 +257,6 @@ class UnitTest:
 
       # Look for numdiff in $PATH
       self.numdiff_exe = which("numdiff"+self.exe_ext)
-      self.numdiff_exe = which("numdiff")
       if (not self.numdiff_exe):
         self.fatal_error("Numdiff not found in PATH")
       if (debug):

--- a/config/application_unit_test.py
+++ b/config/application_unit_test.py
@@ -489,7 +489,7 @@ class UnitTest:
 
       # make a list of clean argument (no spaces, no empty strings)
       clean_run_args = []
-      for arg in self.numdiff_run_cmd.split():
+      for arg in numdiff_run_cmd.split():
         clean_run_args.append(arg)
       if self.numdiff_exe.strip():
         clean_run_args.append(self.numdiff_exe.strip())
@@ -570,7 +570,7 @@ class UnitTest:
 
       # make a list of clean argument (no spaces, no empty strings)
       clean_run_args = []
-      for arg in self.diff_run_cmd.split():
+      for arg in diff_run_cmd.split():
         clean_run_args.append(arg)
       if diff_exe.strip():
         clean_run_args.append(diff_exe.strip())


### PR DESCRIPTION
+ Make a list of arguments that do not have trailing whitespace or empty strings to pass to subprocess
+ Remove the shell=True option from all subprocess calls
+ Use subprocess.Popen call to avoid output files for the simple `draco_info` call
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
