### PR TITLE
Regression fix for Capsaicin and minor script change.

### DIFF
--- a/regression/alist.sh
+++ b/regression/alist.sh
@@ -36,7 +36,7 @@ IFS=$'\r\n' GLOBIGNORE='*' command eval 'user_list=($(cat $author_list_file))'
 author_loc=`mktemp`
 for name in "${user_list[@]}"; do
 
-  numlines=`git log --author="$name" --pretty=tformat: --numstat | awk '{ add += $1; subs += $2; loc += $1 - $2; sum += $1 + $2 } END { printf "%s:\n", sum }'`
+  numlines=`git log --author="$name" --pretty=tformat: --numstat | awk '{ add += $1; subs += $2; loc += $1 - $2; sum += $1 + $2 } END { printf "%s:\n", loc }'`
   echo "$numlines$name"
 
 done | sort -rn > $author_loc

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -207,6 +207,36 @@ case ${target} in
       run "mkdir -p $gitroot/jayenne; cd $gitroot/jayenne"
       run "git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne.git"
     fi
+    # HPC: Mirror the capsaicin svn repository
+    #
+    if ! test -d $svnroot; then
+      echo "*** ERROR ***"
+      echo "*** SVN repository not found ***"
+      exit 1
+      # http://journal.paul.querna.org/articles/2006/09/14/using-svnsync/
+      # mkdir -p ${svnroot}; cd ${svnroot}
+      # svnadmin create ${svnroot}/jayenne
+      # chgrp -R draco jayenne; chmod -R g+rwX,o=g-w jayenne
+      # cd jayenne/hooks
+      # cp pre-commit.tmpl pre-commit; chmod 775 pre-commit
+      # vi pre-commit; comment out all code and add...
+      #if ! test `whoami` = 'kellyt'; then
+      #echo "This is a read only repository.  The real SVN repository is"
+      #echo "at svn+ssh://ccscs8/ccs/codes/radtran/svn/draco."
+      #exit 1
+      #fi
+      #exit 0
+      # cp pre-revprop-change.tmpl pre-revprop-change; chmod 775 \
+      #    pre-revprop-change
+      # vi pre-revprop-change --> comment out all code.
+      # cd $svnroot
+      # svnsync init file:///${svnroot}/jayenne svn+ssh://ccscs8/ccs/codes/radtran/svn/jayenne
+      # svnsync sync file:///${svnroot}/jayenne
+    fi
+
+    echo " "
+    echo "Copy capsaicin svn repository to the local file system..."
+    run "svnsync --non-interactive sync file:///${svnroot}/capsaicin"
     ;;
   tt-fey*)
     TMPFILE=$(mktemp /var/tmp/repo_sync.XXXXXXXXXX) || { echo "failed to create temp file"; exit 1; }
@@ -284,39 +314,6 @@ case ${target} in
       run "git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne.git"
     fi
     ;;
-  # *)
-  #   #
-  #   # HPC: Mirror the capsaicin svn repository
-  #   #
-  #   if ! test -d $svnroot; then
-  #     echo "*** ERROR ***"
-  #     echo "*** SVN repository not found ***"
-  #     exit 1
-  #     # http://journal.paul.querna.org/articles/2006/09/14/using-svnsync/
-  #     # mkdir -p ${svnroot}; cd ${svnroot}
-  #     # svnadmin create ${svnroot}/jayenne
-  #     # chgrp -R draco jayenne; chmod -R g+rwX,o=g-w jayenne
-  #     # cd jayenne/hooks
-  #     # cp pre-commit.tmpl pre-commit; chmod 775 pre-commit
-  #     # vi pre-commit; comment out all code and add...
-  #     #if ! test `whoami` = 'kellyt'; then
-  #     #echo "This is a read only repository.  The real SVN repository is"
-  #     #echo "at svn+ssh://ccscs8/ccs/codes/radtran/svn/draco."
-  #     #exit 1
-  #     #fi
-  #     #exit 0
-  #     # cp pre-revprop-change.tmpl pre-revprop-change; chmod 775 \
-  #     #    pre-revprop-change
-  #     # vi pre-revprop-change --> comment out all code.
-  #     # cd $svnroot
-  #     # svnsync init file:///${svnroot}/jayenne svn+ssh://ccscs8/ccs/codes/radtran/svn/jayenne
-  #     # svnsync sync file:///${svnroot}/jayenne
-  #   fi
-
-  #   echo " "
-  #   echo "Copy capsaicin svn repository to the local file system..."
-  #   run "svnsync --non-interactive sync file:///${svnroot}/capsaicin"
-  #   ;;
 esac
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
+ We haven't been mirroring the capsaicin svn repository to moonlight.  This means that nightly regressions are checking an out-of-date version of capsaicin on Moonlight and trinitite. Fixed.
+ Provide a small tweak to alist.sh that should have been committed with the draco-6_20_0 merge.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation

