### PR TITLE
Another attempt to fix fetch_co.sh.

### DIFF
--- a/regression/fetch_co.sh
+++ b/regression/fetch_co.sh
@@ -48,10 +48,30 @@ fi
 thisbranch=`git rev-parse --abbrev-ref HEAD`
 log "thisbranch = $thisbranch"
 
+# If the branch already exists in the regression source directory, remove it and
+# fetch it again.
 if test "$thisbranch" = "pr${featurebranch}"; then
-  run "${GIT} reset --hard origin/develop"
-  run "${GIT} pull origin $prdir/${featurebranch}/head"
-else
-  run "${GIT} fetch origin ${prdir}/${featurebranch}/head:pr${featurebranch}"
-  run "${GIT} checkout pr${featurebranch}"
+  # run "${GIT} reset --hard origin/develop"
+  run "${GIT} checkout develop"
+  run "${GIT} branch -D pr${featurebranch}"
+  # run "${GIT} pull origin $prdir/${featurebranch}/head"
 fi
+run "${GIT} fetch origin ${prdir}/${featurebranch}/head:pr${featurebranch}"
+run "${GIT} checkout pr${featurebranch}"
+
+# Another option is to edit .git/config:
+# [core]
+#         repositoryformatversion = 0
+#         filemode = true
+#         bare = false
+#         logallrefupdates = true
+# [remote "origin"]
+#         url = git@github.com:losalamos/Draco.git
+#         fetch = +refs/heads/*:refs/remotes/origin/*
+#         fetch = +refs/pull/*/head:refs/remotes/origin/pr/*
+# [branch "develop"]
+#         remote = origin
+#         merge = refs/heads/develop
+# so that 'git fetch origin' fetches all PRs and 'git checkout pr/999' will be a
+# tracking branch. The problem with this approach is that all PRs are downloaded
+# and this can take time.


### PR DESCRIPTION
+ Change the logic flow for cloning/updating the source associated with a PR.
+ The regression always starts from a clone of `develop` for a new PR.
+ If this is the first attempt at testing the PR, the updated files are fetched in a new local branch with the name `pr999` and the regression system uses this source tree.
```
  git fetch origin pull/999/head:pr999
```
+ If this is not the first regression attempt for the PR, then we will switch back to `develop` and delete the `pr999` branch before fetching it again.
```
  git checkout develop
  git branch -D pr999
  git fetch origin pull/999/head:pr999
```
+ There is probably a more elagant solution (like `git pull origin pull/999/head`) but I can't get that to work in a robust way.  Suggestions are welcome.
+ refs #815

* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * Normal CI tests are not relevant to this PR.
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
