### PR TITLE
Update Travis CI runner scripts

### DIFF
--- a/.travis-install-dependencies.sh
+++ b/.travis-install-dependencies.sh
@@ -11,7 +11,7 @@
 # not provided by travis or by apt-get.
 
 # preliminaries and environment
-
+set -e
 source regression/scripts/common.sh
 
 topdir=`pwd` # /home/travis/build/losalamos/Draco
@@ -21,32 +21,67 @@ topdir=`pwd` # /home/travis/build/losalamos/Draco
 RANDOM123_VER=1.09
 CMAKE_VERSION=3.6.2-Linux-x86_64
 NUMDIFF_VER=5.8.1
+CLANG_FORMAT_VER=3.9
+OPENMPI_VER=1.10.3
 
-# Random123
-echo " "
-echo "Random123"
-cd $HOME
-run "wget https://www.deshawresearch.com/downloads/download_random123.cgi/Random123-${RANDOM123_VER}.tar.gz"
-run "tar -xvf Random123-${RANDOM123_VER}.tar.gz"
-echo "Please set RANDOM123_INC_DIR=$HOME/Random123-${RANDOM123_VER}/include"
-run "ls $HOME/Random123-${RANDOM123_VER}/include"
+# printenv
 
-# CMake
-echo " "
-echo "CMake"
-run "cd $HOME"
-run "wget --no-check-certificate http://www.cmake.org/files/v${CMAKE_VERSION:0:3}/cmake-${CMAKE_VERSION}.tar.gz"
-run "tar -xzf cmake-${CMAKE_VERSION}.tar.gz"
-run "cd $topdir"
+if [[ ${STYLE} ]]; then
 
-# Numdiff
-echo " "
-echo "Numdiff"
-run "wget http://mirror.lihnidos.org/GNU/savannah/numdiff/numdiff-${NUMDIFF_VER}.tar.gz"
-run "tar -xvf numdiff-${NUMDIFF_VER}.tar.gz"
-run "cd numdiff-${NUMDIFF_VER}"
-run "./configure --prefix=/usr && make"
-run "sudo make install"
-run "cd $topdir"
+  # clang-format and git-clang-format
+  echo " "
+  echo "Clang-format"
+  run "sudo add-apt-repository 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-${CLANG_FORMAT_VER} main'"
+  run "wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -"
+  run "sudo apt-get update -qq"
+  run "sudo apt-get install -qq -y clang-format-${CLANG_FORMAT_VER}"
+  run "cd ${VENDOR_DIR}/bin"
+  run "ln -s /usr/bin/clang-format-${CLANG_FORMAT_VER} clang-format"
+  run "ln -s /usr/bin/git-clang-format-${CLANG_FORMAT_VER} git-clang-format"
+  run "cd $topdir"
+
+else
+
+  # Random123
+  echo " "
+  echo "Random123"
+  cd $HOME
+  run "wget https://www.deshawresearch.com/downloads/download_random123.cgi/Random123-${RANDOM123_VER}.tar.gz"
+  run "tar -xvf Random123-${RANDOM123_VER}.tar.gz"
+  echo "Please set RANDOM123_INC_DIR=$HOME/Random123-${RANDOM123_VER}/include"
+  run "ls $HOME/Random123-${RANDOM123_VER}/include"
+
+  # CMake
+  echo " "
+  echo "CMake"
+  run "cd $HOME"
+  run "wget --no-check-certificate http://www.cmake.org/files/v${CMAKE_VERSION:0:3}/cmake-${CMAKE_VERSION}.tar.gz"
+  run "tar -xzf cmake-${CMAKE_VERSION}.tar.gz"
+  run "cd $topdir"
+
+  # Numdiff
+  echo " "
+  echo "Numdiff"
+  run "wget http://mirror.lihnidos.org/GNU/savannah/numdiff/numdiff-${NUMDIFF_VER}.tar.gz"
+  run "tar -xvf numdiff-${NUMDIFF_VER}.tar.gz"
+  run "cd numdiff-${NUMDIFF_VER}"
+  run "./configure --prefix=/usr && make"
+  run "sudo make install"
+  run "cd $topdir"
+
+  # OpenMPI
+  echo " "
+  echo "OpenMPI"
+  run "wget --no-check-certificate https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-${OPENMPI_VER}.tar.gz"
+  run "tar -zxf openmpi-${OPENMPI_VER}.tar.gz"
+  run "cd openmpi-${OPENMPI_VER}"
+  run "./configure --enable-mpi-thread-multiple --quiet > build-openmpi.log"
+  run "make >> build-openmpi.log"
+  run "sudo make install"
+  run "sudo sh -c 'echo \"/usr/local/lib\n/usr/local/lib/openmpi\" > /etc/ld.so.conf.d/openmpi.conf'"
+  run "sudo ldconfig"
+  run "cd $topdir"
+
+fi
 
 # Finish up and report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,69 +1,63 @@
 language: cpp
 sudo: required
+dist: trusty
 
 # Notes:
 # $HOME -> /home/travis
 # code checked out to (this is $PWD for the script) -> /home/travis/build/losalamos/Draco
 # travis will not install numdiff -> use ./.travis-install-dependencies.sh.
 
+env:
+  global:
+    - BLAS_blas_LIBRARY=/usr/lib/libblas.a
+    - CC=gcc-5
+    - CCACHE_CPP2=yes
+    - CMAKE=$HOME/cmake-3.6.2-Linux-x86_64/bin/cmake
+    - CTEST=$HOME/cmake-3.6.2-Linux-x86_64/bin/ctest
+    - CXX=g++-5
+    - FC=gfortran-5
+    - LAPACK_LIB_DIR=/usr/lib
+    - OMP_NUM_THREADS=4
+    - RANDOM123_INC_DIR=$HOME/Random123-1.09/include
+    - VENDOR_DIR=${HOME}
+    - topdir=/home/travis/build/losalamos/Draco
+    - COVERAGE=ON
+  matrix:
+    - STYLE=ON
+    - WERROR=ON
+
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.8
     packages:
       - ccache
       - libgsl0-dev
-      - libopenmpi-dev
-      - openmpi-bin
       - gcc-5
       - g++-5
       - gfortran-5
       - liblapack-dev
-      - clang-format-3.8
-
-env:
-  global:
-    - topdir=/home/travis/build/losalamos/Draco
-    - CCACHE_CPP2=yes
-    - GVER=5
-    - CMAKE_VERSION=3.6.2-Linux-x86_64
-    - CMAKE=$HOME/cmake-${CMAKE_VERSION}/bin/cmake
-    - CTEST=$HOME/cmake-${CMAKE_VERSION}/bin/ctest
-    - RANDOM123_VER=1.09
-    - RANDOM123_INC_DIR=$HOME/Random123-${RANDOM123_VER}/include
-    - LAPACK_LIB_DIR=/usr/lib
-    - BLAS_blas_LIBRARY=/usr/lib/libblas.a
-    - J=2
-    - OMP_NUM_THREADS=4
-    - CLANG_FORMAT_VER=3.8
-    - VENDOR_DIR=${HOME}
-  matrix:
-    - STYLE=ON
-    - WERROR=ON
-    - COVERAGE=ON
 
 before_install:
- - if [[ ${GVER} ]]; then export CC=gcc-${GVER}; export CXX=g++-${GVER}; export FC=gfortran-${GVER}; fi
- - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
+  - mkdir -p ${VENDOR_DIR}/bin & export PATH=${VENDOR_DIR}/bin:$PATH
+  - if [[ ${COVERAGE}  ]]; then pip install --user codecov; fi
 
 install: ./.travis-install-dependencies.sh
 
 before_script:
- - if [[ ${WERROR} ]]; then for i in CC CXX FC; do eval export ${i}=\"${!i} -Werror\"; done; fi
- - if [[ ${COVERAGE}  ]]; then for i in CC CXX FC; do eval export ${i}=\"${!i} --coverage\"; done; fi
-# - cd $topdir && echo $CMAKE && $CMAKE --version && which numdiff && printenv
+  - if [[ ${WERROR} ]]; then for i in CC CXX FC; do eval export ${i}=\"${!i} -Werror\"; done; fi
+  - if [[ ${COVERAGE} ]]; then for i in CC CXX FC; do eval export ${i}=\"${!i} --coverage\"; done; fi
 
 script:
     # -Wl,--no-as-needed is a workaround for bugs.debian.org/457284 .
   - if [[ ${STYLE} ]]; then regression/check_style.sh -t; else mkdir -p build && cd build &&
     ${CMAKE} -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-as-needed" .. &&
-    make -j${J} VERBOSE=1 &&
-    ${CTEST} -j ${J} -E \(c4_tstOMP_2\) &&
+    make -j 2 VERBOSE=1 &&
+    ${CTEST} -j 2 -E \(c4_tstOMP_2\) &&
     make install DESTDIR="${HOME}" && cd - ; fi
 
 after_success:
-  - if [[ ${COVERAGE} ]]; then codecov --gcov-exec gcov-${GVER}; fi
+  - if [[ ${COVERAGE} ]]; then codecov --gcov-exec gcov-5; fi
 
 cache:
   - ccache
@@ -81,7 +75,6 @@ git:
 # CC=gcc-5
 # CCACHE_CPP2=yes
 # CI=true
-# CLANG_FORMAT_VER=3.8
 # CMAKE=/home/travis/cmake-3.5.2-Linux-x86_64/bin/cmake
 # CMAKE_VERSION=3.5.2-Linux-x86_64
 # COMPOSER_NO_INTERACTION=1
@@ -94,12 +87,10 @@ git:
 # GEM_PATH=/home/travis/.rvm/gems/ruby-2.2.5:/home/travis/.rvm/gems/ruby-2.2.5@global
 # GIT_ASKPASS=echo
 # GOROOT=/home/travis/.gimme/versions/go1.4.2.linux.amd64
-# GVER=5
 # HAS_ANTARES_THREE_LITTLE_FRONZIES_BADGE=true
 # HAS_JOSH_K_SEAL_OF_APPROVAL=true
 # HOME=/home/travis
 # IRBRC=/home/travis/.rvm/rubies/ruby-2.2.5/.irbrc
-# J=2
 # JAVA_HOME=/usr/lib/jvm/java-7-oracle
 # JRUBY_OPTS=--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -Xcext.enabled=false -J-Xss2m -Xcompile.invokedynamic=false
 # LANG=en_US.UTF-8
@@ -127,7 +118,6 @@ git:
 # RACK_ENV=test
 # RAILS_ENV=test
 # RANDOM123_INC_DIR=/home/travis/Random123-1.09/include
-# RANDOM123_VER=1.09
 # RUBY_VERSION=ruby-2.2.5
 # SHELL=/bin/bash
 # SHLVL=2


### PR DESCRIPTION
* Change some of the tools and setup used by travis (CI system for Draco). I am addressing two issues with this change: (1) We are using clang-format-3.9 on our local systems to check formatting requirements.  We should use the same version when running the checks under Travis, and (2) Recent changes to c4 require OpenMPI 1.10+ but Ubuntu 12 and 14 only know about version 1.6.
+ Modify the script that provides vendors to the build environment on travis to provide clang-format-3.9 and git-clang-format-3.9.  Travis's Ubuntu environment doesn't allow installing these versions via apt-get so do it via this script. Also download, build and install openmpi-1.10.3.  Building MPI takes about 10 minutes, so this will make the checks run much slower.
+ Change the travis environment from Ubuntu 12 to 14 (Trusty).
+ No longer use Travis to setup/install openmpi or clang-format.
+ No longer set some environment variables that were not used.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation

