### PR TITLE
Discontinue support/regressions for GPU kernels on Moonlight.

### DIFF
--- a/regression/ml-crontab
+++ b/regression/ml-crontab
@@ -21,34 +21,12 @@
 #------------------------------------------------------------------------------#
 
 #------------------------------------------------------------------------------#
-# CUDA (Intel/15.0.5 and OpenMPI/1.6.5 and CUDA)
-#------------------------------------------------------------------------------#
-
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e cuda -p "draco jayenne" &> /usr/projects/jayenne/regress/logs/ml-Debug-cuda-master.log
-
-01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -e cuda -p "draco jayenne" &> /usr/projects/jayenne/regress/logs/ml-Release-cuda-master.log
-
-#------------------------------------------------------------------------------#
 # Intel/16.0.3 and OpenMPI/1.10.1
 #------------------------------------------------------------------------------#
 
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/ml-Debug-master.log
 
 01 00 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Release -p "draco jayenne capsaicin" &> /usr/projects/jayenne/regress/logs/ml-Release-master.log
-
-#------------------------------------------------------------------------------#
-# Github and PRs
-#------------------------------------------------------------------------------#
-
-# 01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -g -d Nightly -b Debug -p "draco" &> /usr/projects/jayenne/regress/logs/ml-Debug-master.log
-
-# 01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Experimental -b Debug -p "draco" -f pr1 &> /usr/projects/jayenne/regress/logs/ml-Debug-master.log
-
-#------------------------------------------------------------------------------#
-# PGI and OpenMPI/1.6.5
-#------------------------------------------------------------------------------#
-
-# 01 02 * * 0-6 /usr/projects/jayenne/regress/draco/regression/regression-master.sh -r -d Nightly -b Debug -e pgi -p "draco jayenne" &> /usr/projects/jayenne/regress/logs/ml-Debug-pgi-master.log
 
 #------------------------------------------------------------------------------#
 # Special: NR, PerfBench and FullDiagnostics regressions.

--- a/regression/ml-regress.msub
+++ b/regression/ml-regress.msub
@@ -121,19 +121,23 @@ case $extra_params in
     # no-op
     ;;
 cuda)
-    run "module unload eospac ndi parmetis metis"
-    run "module unload superlu-dist trilinos"
-    run "module unload mkl openmpi intel"
-    run "module list"
-    run "module load intel/15.0.5 openmpi/1.6.5"
-# cudatoolkits/5 - 7.5 are incompatible with intel/16.
-#    run "module load intel/16.0.3 openmpi/1.10.1"
-    run "module load mkl trilinos/12.6.1 superlu-dist metis"
-    run "module load parmetis ndi"
-    run "module load numdiff subversion git"
-    run "module load random123 eospac/6.2.4 grace"
-    run "module load cudatoolkit/7.5"
-    comp="${comp}-cuda"
+    echo "ERROR: CUDA is no longer supported."
+    echo "Draco requires openmpi-1.10.3, which only provided for Intel/16+."
+    echo "The cudatoolkit is only compatible with Intel < 16."
+    exit 1
+#     run "module unload eospac ndi parmetis metis"
+#     run "module unload superlu-dist trilinos"
+#     run "module unload mkl openmpi intel"
+#     run "module list"
+#     run "module load intel/16.0.3 openmpi/1.10.3"
+# # cudatoolkits/5 - 7.5 are incompatible with intel/16.
+# #    run "module load intel/16.0.3 openmpi/1.10.1"
+#     run "module load mkl trilinos/12.6.1 superlu-dist metis"
+#     run "module load parmetis ndi"
+#     run "module load numdiff subversion git"
+#     run "module load random123 eospac/6.2.4 grace"
+#     run "module load cudatoolkit/7.5"
+#     comp="${comp}-cuda"
     ;;
 fulldiagnostics)
     comp="${comp}-fulldiagnostics"

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -26,7 +26,7 @@ export host=`uname -n | sed -e 's/[.].*//g'`
 ##---------------------------------------------------------------------------##
 ccs_extra_params="belosmods bounds_checking clang coverage fulldiagnostics gcc530 gcc610 nr perfbench valgrind "
 darwin_extra_params="cuda fulldiagnostics nr perfbench valgrind"
-ml_extra_params="cuda fulldiagnostics nr perfbench pgi valgrind"
+ml_extra_params="fulldiagnostics nr perfbench pgi valgrind"
 sn_extra_params="fulldiagnostics nr perfbench"
 tt_extra_params="fulldiagnostics knl nr perfbench"
 all_extra_params=`echo $ml_extra_params $tt_extra_params $sn_extra_params $ccs_extra_params $darwin_extra_params | xargs -n1 | sort -u | xargs`
@@ -208,7 +208,7 @@ ml-*)
     if [[ ${extra_params} ]]; then
         case $extra_params in
         none)  extra_params=""; epdash="" ;;
-        cuda | fulldiagnostics | nr | perfbench | pgi | valgrind ) # known, continue
+        fulldiagnostics | nr | perfbench | pgi | valgrind ) # known, continue
         ;;
         *) echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
            print_use; exit 1 ;;


### PR DESCRIPTION
+ Remove cuda-based regressions from example crontab.
+ Remove 'cuda' option for Moonlight from regression-master.sh.
+ Print an error message if 'cuda' regressions are attempted from Moonlight.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
