### PR TITLE
Update release scripts and environments for the release of Draco-6_20_1.

### DIFF
--- a/.travis-install-dependencies.sh
+++ b/.travis-install-dependencies.sh
@@ -28,6 +28,20 @@ OPENMPI_VER=1.10.3
 
 if [[ ${STYLE} ]]; then
 
+  # Ensure the 'develop' branch is available.  In some cases (merge a branch
+  # that lives at github.com/losalamos), the develop branch is missing in the
+  # travis checkout. Since we only test files that are modified when comapred to
+  # the 'develop' branch, the develop branch must be available locally.
+  dev_branch_found=`git branch -a | grep -c develop`
+  if [[ ! $dev_branch_found ]]; then
+    # Register the develop branch in draco/.git/config
+    git config --local remote.origin.fetch +refs/heads/develop:refs/remotes/origin/develop
+    # Download the meta-data for the 'develop' branch
+    git fetch
+    # Create a local tracking branch
+    git branch -t develop origin/develop
+  fi
+
   # clang-format and git-clang-format
   echo " "
   echo "Clang-format"

--- a/.travis-install-dependencies.sh
+++ b/.travis-install-dependencies.sh
@@ -24,6 +24,14 @@ NUMDIFF_VER=5.8.1
 CLANG_FORMAT_VER=3.9
 OPENMPI_VER=1.10.3
 
+# Return integer > 0 if 'develop' branch is found.
+function find_dev_branch
+{
+  set -f
+  git branch -a | grep -c develop
+  set +f
+}
+
 # printenv
 
 if [[ ${STYLE} ]]; then
@@ -32,14 +40,15 @@ if [[ ${STYLE} ]]; then
   # that lives at github.com/losalamos), the develop branch is missing in the
   # travis checkout. Since we only test files that are modified when comapred to
   # the 'develop' branch, the develop branch must be available locally.
-  dev_branch_found=`git branch -a | grep -c develop`
-  if [[ ! $dev_branch_found ]]; then
+  num_dev_branches_found=`find_dev_branch`
+  if [[ $num_dev_branches_found == 0 ]]; then
+    echo "no develop branches found."
     # Register the develop branch in draco/.git/config
-    git config --local remote.origin.fetch +refs/heads/develop:refs/remotes/origin/develop
+    run "git config --local remote.origin.fetch +refs/heads/develop:refs/remotes/origin/develop"
     # Download the meta-data for the 'develop' branch
-    git fetch
+    run "git fetch"
     # Create a local tracking branch
-    git branch -t develop origin/develop
+    run "git branch -t develop origin/develop"
   fi
 
   # clang-format and git-clang-format

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,28 @@
+2016-11-16  Kelly (KT) Thompson  <kgt@lanl.gov>
+
+	* Release draco-6_20_1. This is a patch release.
+	  https://rtt.lanl.gov/redmine/versions/49
+
+	* This release was required by Jayenne and Capsaicin.  It is
+	  linked to:
+	  - Jayenne-7_12_0,  https://rtt.lanl.gov/redmine/versions/47
+	  - Capsaicin-4_9_0, https://rtt.lanl.gov/redmine/projects/capsaicin
+
+	* Platforms:
+	  PI/ML/LU           Intel 16.0.3    OpenMPI-1.10.3
+	  SN/FI/IC           Intel 16.0.3    OpenMPI-1.10.3
+	  TT/TR              Intel 16.0.3    Cray_MPICH2-7.4.2
+	  SQ                 GCC 5.3.0       MPICH2-1.5.0
+
+	* Summary of changes:
+	- 33 files changed, added or removed in 32 commits.
+	- Provide initial support for snow/fire/ice. #826
+	- Initial commit of Invert_Comm_Map, using RMA.
+	- Discontinue support/regressions for GPU kernels on Moonlight.
+	- Provide regressions for Trinitite/KNL. #824
+	- No longer generate a library for package 'fit'
+	- Move defaults to cmake/3.6.2 and trilinos/12.8.1 (tt only).
+
 2016-11-02  Kelly (KT) Thompson  <kgt@lanl.gov>
 
 	* Release draco-6_20_0. This is a minor Draco release.

--- a/config/setupMPI.cmake
+++ b/config/setupMPI.cmake
@@ -312,6 +312,15 @@ WARNING: ENV{OMP_NUM_THREADS} is not set in your environment,
   set( MPIEXEC_NUMPROC_FLAG "-n" CACHE
     STRING "flag used to specify number of processes." FORCE)
 
+  # [2016-11-17 KT] Ensure that the MPI headers in mpi.h use function signatures
+  # from the MPI-2.2 standard that include 'const' parameters for MPI_put. The
+  # MPI headers found on Sequoia claim to be MPI-2.2 compliant. However, this
+  # CPP macro has been altered to be empty and this violates the v. 2.2
+  # standard. For compatibility with the CCS-2 codebase, manually set this CPP
+  # macro back to 'const'.  This definition will appear in c4/config.h.
+  set( MPICH2_CONST "const" "Sequoia MPICH2-1.5 compile option.")
+  mark_as_advanced( MPICH2_CONST )
+
 endmacro()
 
 #------------------------------------------------------------------------------#

--- a/config/unix-ifort.cmake
+++ b/config/unix-ifort.cmake
@@ -19,22 +19,36 @@ if( NOT Fortran_FLAGS_INITIALIZED )
   # [KT 2015-07-10] -diag-disable 11060 -- disable warning that is issued when
   #    '-ip' is turned on and a library has no symbols (this occurs when
   #    capsaicin links some trilinos libraries.)
-  set( CMAKE_Fortran_FLAGS                "-warn  -fpp -implicitnone -diag-disable 11060" )
-  set( CMAKE_Fortran_FLAGS_DEBUG          "-g -O0 -traceback -ftrapuv -check -DDEBUG" )
-  set( CMAKE_Fortran_FLAGS_RELEASE        "-O2 -inline-level=2 -fp-speculation fast -fp-model fast -align array32byte -funroll-loops -DNDEBUG" )
-  set( CMAKE_Fortran_FLAGS_MINSIZEREL     "${CMAKE_Fortran_FLAGS_RELEASE}" )
-  set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -O2 -inline-level=2 -funroll-loops -DDEBUG" )
+  # [KT 2016-11-16] -diag-disable 11021 -- disable warning that is issued when
+  #    '-ip' is turned on and a library has unresolved symbols (this occurs when
+  #    capsaicin links to openmpi/1.10.3 on snow/fire/ice).
+  #    Ref: https://github.com/open-mpi/ompi/issues/251
+  set( CMAKE_Fortran_FLAGS
+    "-warn  -fpp -implicitnone -diag-disable 11060" )
+  set( CMAKE_Fortran_FLAGS_DEBUG
+    "-g -O0 -traceback -ftrapuv -check -DDEBUG" )
+  set( CMAKE_Fortran_FLAGS_RELEASE
+    "-O2 -inline-level=2 -fp-speculation fast -fp-model fast -align array32byte -funroll-loops -diag-disable 11021 -DNDEBUG" )
+  set( CMAKE_Fortran_FLAGS_MINSIZEREL
+    "${CMAKE_Fortran_FLAGS_RELEASE}" )
+  set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO
+    "-g -O2 -inline-level=2 -funroll-loops -DDEBUG" )
 
 endif()
 
 ##---------------------------------------------------------------------------##
 # Ensure cache values always match current selection
 ##---------------------------------------------------------------------------##
-set( CMAKE_Fortran_FLAGS                "${CMAKE_Fortran_FLAGS}"                CACHE STRING "compiler flags" FORCE )
-set( CMAKE_Fortran_FLAGS_DEBUG          "${CMAKE_Fortran_FLAGS_DEBUG}"          CACHE STRING "compiler flags" FORCE )
-set( CMAKE_Fortran_FLAGS_RELEASE        "${CMAKE_Fortran_FLAGS_RELEASE}"        CACHE STRING "compiler flags" FORCE )
-set( CMAKE_Fortran_FLAGS_MINSIZEREL     "${CMAKE_Fortran_FLAGS_MINSIZEREL}"     CACHE STRING "compiler flags" FORCE )
-set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}" CACHE STRING "compiler flags" FORCE )
+set( CMAKE_Fortran_FLAGS                "${CMAKE_Fortran_FLAGS}"
+  CACHE STRING "compiler flags" FORCE )
+set( CMAKE_Fortran_FLAGS_DEBUG          "${CMAKE_Fortran_FLAGS_DEBUG}"
+  CACHE STRING "compiler flags" FORCE )
+set( CMAKE_Fortran_FLAGS_RELEASE        "${CMAKE_Fortran_FLAGS_RELEASE}"
+  CACHE STRING "compiler flags" FORCE )
+set( CMAKE_Fortran_FLAGS_MINSIZEREL     "${CMAKE_Fortran_FLAGS_MINSIZEREL}"
+  CACHE STRING "compiler flags" FORCE )
+set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}"
+  CACHE STRING "compiler flags" FORCE )
 
 # Optional compiler flags
 if( NOT ${SITENAME} STREQUAL "Trinitite" )

--- a/environment/cshrc/.cshrc
+++ b/environment/cshrc/.cshrc
@@ -109,12 +109,14 @@ case seqlac*:
     setenv DK_NODE ${DK_NODE}:${VENDOR_DIR}/Modules/sq
 
     # Draco dotkits
-    use xlc12 # use gcc472
+    # use xlc12
+    use gcc484
     use numdiff
     use random123
+    use gsl
 
     # LLNL dotkits
-    use cmake331
+    use cmake361
     use erase=del
     use alia1++
 

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -191,8 +191,7 @@ function lookupppn()
   local ppn=1
   case ${target} in
     ml* | pi* | wf* | lu* ) ppn=16 ;;
-    mu* ) ppn=24 ;;
-    t[rt]-fey* | t[rt]-login*) ppn=32 ;;
+    t[rt]-fe* | t[rt]-login*) ppn=32 ;;
     sn* ) ppn=36 ;;
   esac
   echo $ppn

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -36,7 +36,7 @@ function establish_permissions
     install_permissions="g+rwX,o-rwX"
   else
     install_group="draco"
-    install_permissions="g+rwX,o=g-w"
+    install_permissions="g+rwX,o-rwX"
   fi
   build_group="$USER"
   build_permissions="g+rwX,o-rwX"
@@ -304,6 +304,8 @@ function install_versions
   echo
   run "module list"
   run "printenv"
+  echo "---"
+  echo "Environment size = `printenv | wc -c`"
 
   echo
   echo

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -169,7 +169,7 @@ function selectscratchdir
   # TOSS, CLE, BGQ, Darwin:
   toss2_yellow_scratchdirs="lustre/scratch2/yellow lustre/scratch3/yellow"
   toss2_red_scratchdirs="lustre/scratch3 lustre/scratch4"
-  cray_yellow_scratchdirs="lustre/ttscratch"
+  cray_yellow_scratchdirs="lustre/ttscratch1"
   cray_red_scratchdirs="lustre/trscratch1 lustre/trscratch2"
   bgq_scratchdirs="nfs/tmp2"
   scratchdirs="$toss2_yellow_scratchdirs $toss2_red_scratchdirs \

--- a/regression/scripts/release_bgq.msub
+++ b/regression/scripts/release_bgq.msub
@@ -33,6 +33,22 @@ if test $verbose == 1; then
   echo
 fi
 
+# Sequoia limits the environment size to 8192, so clean up to keep the
+# environment below this limit.
+unset LS_COLORS
+unset MANPATH
+unset NLSPATH
+unset EXINIT
+unset CLASSPATH
+unset QTDIR
+unset QTLIB
+unset QTINC
+unset DRACO_AUTO_CLANG_FORMAT
+unset EDITOR
+unset SSH_ASKPASS
+unset CVS_RSH
+unset CEI_HOME
+
 # dry_run=1
 install_versions
 

--- a/regression/scripts/release_bgq.sh
+++ b/regression/scripts/release_bgq.sh
@@ -45,7 +45,7 @@ function gcc484()
   export VENDOR_DIR=/usr/gapps/jayenne/vendors
   export DK_NODE=$DK_NODE:/$VENDOR_DIR/Modules/sq
   export OMP_NUM_THREADS=4
-  use gcc484
+  use gcc484 python-2.7.3
   use cmake361 gsl numdiff random123
   use
 }

--- a/regression/scripts/release_bgq.sh
+++ b/regression/scripts/release_bgq.sh
@@ -34,22 +34,19 @@ set +u
 
 # Draco install directory name (/usr/projects/draco/draco-NN_NN_NN)
 export package=draco
-ddir=draco-6_18_0
+ddir=draco-6_20_1
 pdir=$ddir
-
-# CMake options that will be included in the configuration step
-export CONFIG_BASE="-DDRACO_VERSION_PATCH=0 -DDRACO_LIBRARY_TYPE=STATIC"
 
 # environment (use draco modules)
 # release for each module set
-environments="gcc484 xlc12"
+environments="gcc484"
 function gcc484()
 {
   export VENDOR_DIR=/usr/gapps/jayenne/vendors
   export DK_NODE=$DK_NODE:/$VENDOR_DIR/Modules/sq
   export OMP_NUM_THREADS=4
   use gcc484
-  use cmake340 gsl numdiff random123
+  use cmake361 gsl numdiff random123
   use
 }
 function xlc12()
@@ -77,6 +74,9 @@ export draco_script_dir=$script_dir
 cd $cdir
 source $draco_script_dir/common.sh
 
+# CMake options that will be included in the configuration step
+export CONFIG_BASE="-DDRACO_LIBRARY_TYPE=STATIC -DDRACO_VERSION_PATCH=`echo $ddir | sed -e 's/.*_//'`"
+
 # sets umask 0002
 # sets $install_group, $install_permissions, $build_permissions
 establish_permissions
@@ -85,6 +85,22 @@ export source_prefix="/usr/gapps/jayenne/$pdir"
 scratchdir=`selectscratchdir`
 build_pe=`npes_build`
 test_pe=`npes_test`
+
+# Sequoia limits the environment size to 8192, so clean up to keep the
+# environment below this limit.
+unset LS_COLORS
+unset MANPATH
+unset NLSPATH
+unset EXINIT
+unset CLASSPATH
+unset QTDIR
+unset QTLIB
+unset QTINC
+unset DRACO_AUTO_CLANG_FORMAT
+unset EDITOR
+unset SSH_ASKPASS
+unset CVS_RSH
+unset CEI_HOME
 
 # =============================================================================
 # Build types:

--- a/regression/scripts/release_cray.sh
+++ b/regression/scripts/release_cray.sh
@@ -27,7 +27,7 @@
 
 # Draco install directory name (/usr/projects/draco/draco-NN_NN_NN)
 export package=draco
-ddir=draco-6_20_0
+ddir=draco-6_20_1
 pdir=$ddir
 
 # environment (use draco modules)
@@ -189,8 +189,10 @@ for env in $environments; do
 
     # Run the tests on the back-end.
     export steps="test"
-    cmd="msub -V $access_queue -l walltime=08:00:00 -l nodes=2:ppn=${ppn} -j oe \
--o $source_prefix/logs/release-$buildflavor-$version-t.log $draco_script_dir/release_cray.msub"
+    cmd="msub -V $access_queue -l walltime=08:00:00 \
+-l nodes=2:haswell:ppn=${ppn} -j oe \
+-o $source_prefix/logs/release-$buildflavor-$version-t.log \
+$draco_script_dir/release_cray.msub"
     echo -e "\nTest $package for $buildflavor-$version."
     echo "$cmd"
     jobid=`eval ${cmd}`

--- a/regression/scripts/release_cray.sh
+++ b/regression/scripts/release_cray.sh
@@ -35,7 +35,7 @@ pdir=$ddir
 target="`uname -n | sed -e s/[.].*//`"
 case $target in
   t[rt]-fe* | t[rt]-login* )
-    environments="intel16env" ;;
+    environments="intel17env" ;;
 esac
 function intel16env()
 {
@@ -60,6 +60,29 @@ export CRAYPE_LINK_TYPE=dynamic
 export OMP_NUM_THREADS=16
 }
 
+function intel17env()
+{
+run "module load user_contrib friendly-testing"
+run "module unload ndi metis parmetis superlu-dist trilinos"
+run "module unload lapack gsl intel"
+run "module unload cmake numdiff"
+run "module unload intel gcc"
+run "module unload PrgEnv-intel PrgEnv-cray PrgEnv-gnu"
+run "module unload papi perftools"
+run "module load PrgEnv-intel"
+run "module unload xt-libsci xt-totalview intel"
+run "module load intel/17.0.1"
+run "module load gsl/2.1"
+run "module load cmake/3.6.2 numdiff"
+run "module load trilinos/12.8.1 superlu-dist/4.3 metis/5.1.0 parmetis/4.0.3"
+run "module load ndi random123 eospac/6.2.4"
+run "module list"
+CC=`which cc`
+CXX=`which CC`
+FC=`which ftn`
+export CRAYPE_LINK_TYPE=dynamic
+export OMP_NUM_THREADS=16
+}
 # function intel14env()
 # {
 # run "module load friendly-testing user_contrib"

--- a/regression/scripts/release_toss2.sh
+++ b/regression/scripts/release_toss2.sh
@@ -32,13 +32,24 @@ pdir=$ddir
 
 # environment (use draco modules)
 # release for each module set
-environments="intel16env"
+environments="intel17env"
 function intel16env()
 {
   run "module purge"
   run "module load friendly-testing user_contrib"
   run "module load cmake/3.6.2 git numdiff"
   run "module load intel/16.0.3 openmpi/1.10.3"
+  run "module load random123 eospac/6.2.4 gsl/2.1"
+  run "module load mkl metis/5.1.0 ndi"
+  run "module load parmetis/4.0.3 superlu-dist/4.3 trilinos/12.8.1"
+  run "module list"
+}
+function intel17env()
+{
+  run "module purge"
+  run "module load friendly-testing user_contrib"
+  run "module load cmake/3.6.2 git numdiff"
+  run "module load intel/17.0.1 openmpi/1.10.3"
   run "module load random123 eospac/6.2.4 gsl/2.1"
   run "module load mkl metis/5.1.0 ndi"
   run "module load parmetis/4.0.3 superlu-dist/4.3 trilinos/12.8.1"

--- a/regression/scripts/release_toss2.sh
+++ b/regression/scripts/release_toss2.sh
@@ -27,7 +27,7 @@
 
 # Draco install directory name (/usr/projects/draco/draco-NN_NN_NN)
 export package=draco
-ddir=draco-6_20_0
+ddir=draco-6_20_1
 pdir=$ddir
 
 # environment (use draco modules)

--- a/src/c4/config.h.in
+++ b/src/c4/config.h.in
@@ -66,6 +66,13 @@
 #endif
 #endif
 
+/* Ensure that Sequoia mpi.h uses 'const' in function signatures. This is
+ * required to meet the MPI-2.2 standars.
+ *
+ * \todo Consider checking the value of $LLNL_MPI_DEFAULT_TO_V1R2M0.
+ */
+#cmakedefine MPICH2_CONST @MPICH2_CONST@
+
 #endif /* rtt_c4_config_h */
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The Draco-6_20_1 release is done except for merging these changes back to `develop`.  

+ Provide a release summary in ChangeLog.
+ For the Intel compiler, disable 'ip' warnings that originate from the MPI libraries. This change targets Snow, Fire and Ice.
+ Update release scripts to use the correct vendors and draco version numbers.
+ Update the BGQ release scripts to clean up the local environment so as to keep the environment below the 8192 max size.
+ Update the cray release scripts to specifically target the haswell architecture.
+ Tweak `c4/config.h` and `config/setupMPI.cmake` to define `MPICH2_CONST` correctly when compiling on Sequoia with gcc-4.8.4.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation


