### PR TITLE
add -no-ftz compile option for intel compiler

### DIFF
--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -42,7 +42,7 @@ if( NOT CXX_FLAGS_INITIALIZED )
     # For floating point consistency with Xeon when using Intel 15.0.090 + Intel MPI 5.0.2
     set( CMAKE_C_FLAGS_DEBUG        "${CMAKE_C_FLAGS_DEBUG} -fp-model precise -fp-speculation safe" )
   endif()
-  set( CMAKE_C_FLAGS_RELEASE        "-O3 -fp-speculation fast -fp-model fast -no-ftz -pthread -DNDEBUG" )
+  set( CMAKE_C_FLAGS_RELEASE        "-O3 -fp-speculation fast -fp-model fast -pthread -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
   set( CMAKE_C_FLAGS_RELWITHDEBINFO "-g -debug inline-debug-info -O3 -pthread -fp-model precise -fp-speculation safe" )
 

--- a/config/unix-intel.cmake
+++ b/config/unix-intel.cmake
@@ -36,13 +36,13 @@ if( NOT CXX_FLAGS_INITIALIZED )
   # [KT 2015-07-10] -diag-disable 11060 -- disable warning that is
   #    issued when '-ip' is turned on and a library has no symbols (this
   #    occurs when capsaicin links some trilinos libraries.)
-  set( CMAKE_C_FLAGS                "-w1 -vec-report0 -diag-disable remark -shared-intel -ftz -diag-disable 11060" )
+  set( CMAKE_C_FLAGS                "-w1 -vec-report0 -diag-disable remark -shared-intel -no-ftz -diag-disable 11060" )
   set( CMAKE_C_FLAGS_DEBUG          "-g -O0 -inline-level=0 -ftrapuv -check=uninit -DDEBUG")
   if( HAVE_MIC )
     # For floating point consistency with Xeon when using Intel 15.0.090 + Intel MPI 5.0.2
     set( CMAKE_C_FLAGS_DEBUG        "${CMAKE_C_FLAGS_DEBUG} -fp-model precise -fp-speculation safe" )
   endif()
-  set( CMAKE_C_FLAGS_RELEASE        "-O3 -fp-speculation fast -fp-model fast -pthread -DNDEBUG" )
+  set( CMAKE_C_FLAGS_RELEASE        "-O3 -fp-speculation fast -fp-model fast -no-ftz -pthread -DNDEBUG" )
   set( CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_RELEASE}" )
   set( CMAKE_C_FLAGS_RELWITHDEBINFO "-g -debug inline-debug-info -O3 -pthread -fp-model precise -fp-speculation safe" )
 


### PR DESCRIPTION
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation

Disable intel compiler option that flushes denormal results to zero.