### PR TITLE
Address undesired behavior for the clang-format pre-commit hook.

### DIFF
--- a/environment/git/pre-commit-clang-format
+++ b/environment/git/pre-commit-clang-format
@@ -163,9 +163,14 @@ fi
 # print the diffs and reject the commit.
 if test $auto_apply = true; then
   git apply "$patch"
-  printf "Files in this commit were updated to comply with the clang-format rules.\n"
+  printf "\nFiles in this commit were updated to comply with the clang-format rules.\n"
+  printf "You must check and test these changes and then stage these updates to\n"
+  printf "be part of your current change set and retry the commit.\n\n"
+  git status
+#  printf "The following changes were applied:\n\n"
+#  cat "$patch"
   rm -f "$patch"
-  exit 0
+  exit 1
 fi
 
 # a patch has been created, notify the user and exit


### PR DESCRIPTION
Previously, setting `DRACO_CLANG_FORMAT=AUTO` would automatically fix style issues in files included in the current change set.  However, these style changes were only applied after the commit - leaving modified files in your working directory. This commit changes the behavior of the pre-commit-hook so that the commit is _aborted_ and instructions are issued to (1) check/test the modified files; (2) git-add the files that were modified to meet style requirements into the current change set; and (3) try the commit again.

* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation

