### PR TITLE
Only build Draco once per day for the Jayenne CI system.

### DIFF
--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -168,20 +168,6 @@ for proj in ${projects}; do
    esac
 done
 
-# if [[ ${extra_params} ]]; then
-#    case $extra_params in
-#    none)
-#       # if 'none' set to blank
-#       extra_params=""; epdash="" ;;
-#    belosmods | bounds_checking | clang | coverage | cuda | fulldiagnostics | knl | gcc530 )
-#       ;;
-#    gcc610 | nr | perfbench | pgi | valgrind )
-#       ;;
-#    *)  echo "" ;echo "FATAL ERROR: unknown extra params (-e) = ${extra_params}"
-#        print_use; exit 1 ;;
-#    esac
-# fi
-
 case $regress_mode in
 on) ;;
 off) userlogdir="/${USER}" ;;


### PR DESCRIPTION
+ Build _Experimental_  _draco-develop_ once per day per machine and special build type (coverage, valgrind, fulldiagnostics, etc.)
+ Use the file `$regdir/logs/last-draco-develop.log` to establish the time of the last draco build.  If this file hasn't been touched since midnight, then build draco before attempting to build a Jayenne PR.
+ If we need to build draco, don't start any jayenne builds until the draco build is complete.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation

