### PR TITLE
On HPC machines, add clang-format to the default Draco environment

### DIFF
--- a/config/doxygen_config.in
+++ b/config/doxygen_config.in
@@ -51,7 +51,7 @@ PROJECT_BRIEF          = "@project_brief@"
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = dragon.png
+PROJECT_LOGO           = dragon.jpg
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is

--- a/environment/bashrc/.bashrc
+++ b/environment/bashrc/.bashrc
@@ -1,7 +1,13 @@
 #!/bin/bash
 ##-*- Mode: bash -*-
 ##---------------------------------------------------------------------------##
-## .bashrc - my bash configuration file upon bash shell startup
+## File  : environment/bashrc/.bashrc
+## Date  : Tuesday, May 31, 2016, 14:48 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##
+##  Bash configuration file upon bash shell startup
 ##---------------------------------------------------------------------------##
 
 ## Instructions (customization)

--- a/environment/bashrc/.bashrc_toss22
+++ b/environment/bashrc/.bashrc_toss22
@@ -53,7 +53,7 @@ else
   fi
   module load friendly-testing
 
-  export dracomodules="intel/17.0.1 openmpi/1.10.3 mkl trilinos/12.8.1 \
+  export dracomodules="clang-format/3.9.0 intel/17.0.1 openmpi/1.10.3 mkl trilinos/12.8.1 \
 superlu-dist/4.3 metis/5.1.0 parmetis/4.0.3 ndi random123 eospac/6.2.4 \
 subversion cmake/3.6.2 numdiff git totalview emacs grace"
 

--- a/environment/bashrc/.bashrc_toss3
+++ b/environment/bashrc/.bashrc_toss3
@@ -53,7 +53,7 @@ else
   fi
   module load friendly-testing
 
-  export dracomodules="intel/17.0.1 openmpi/1.10.3 mkl \
+  export dracomodules="clang-format/3.9.0 intel/17.0.1 openmpi/1.10.3 mkl \
 subversion cmake numdiff git totalview trilinos/12.8.1 \
 superlu-dist/4.3 metis/5.1.0 parmetis/4.0.3 ndi random123 eospac/6.2.4"
 

--- a/environment/bashrc/.bashrc_tt
+++ b/environment/bashrc/.bashrc_tt
@@ -1,6 +1,12 @@
 ##-*- Mode: sh -*-
 ##---------------------------------------------------------------------------##
-## .bashrc_tt - my bash configuration file upon bash login
+## File  : environment/bashrc/.bashrc_tt
+## Date  : Tuesday, May 31, 2016, 14:48 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##
+## Bash configuration file for Cray HPC machines.
 ##---------------------------------------------------------------------------##
 
 if test -n "$verbose"; then
@@ -46,9 +52,9 @@ else
 fi
 module load friendly-testing
 
-export dracomodules="metis parmetis/4.0.3 trilinos/12.8.1 superlu-dist/4.3 \
-gsl/2.1 cmake/3.6.2 numdiff ndi random123 eospac/6.2.4 subversion git \
-craype-hugepages4M"
+export dracomodules="clang-format metis parmetis/4.0.3 trilinos/12.8.1 \
+superlu-dist/4.3 gsl/2.1 cmake/3.6.2 numdiff ndi random123 eospac/6.2.4 \
+subversion git craype-hugepages4M"
 
 function dracoenv ()
 {

--- a/environment/bin/bash_functions.sh
+++ b/environment/bin/bash_functions.sh
@@ -1,12 +1,17 @@
-## -*- Mode: sh -*-----------------------------------------------------------##
-##
-## file  : bash_functions.sh
+## -*- Mode: sh -*-
+##---------------------------------------------------------------------------##
+## File  : environment/bin/bash_functions.sh
+## Date  : Tuesday, May 31, 2016, 14:48 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##---------------------------------------------------------------------------##
 ##
 ## Summary: Misc bash functions useful during development of code.
 ##
 ## 1. Use GNU tools instead of vendor tools when possible
-## 2. Create some alias commands to provide hints when invalid
-##    commands are issued.
+## 2. Create some alias commands to provide hints when invalid commands are
+##    issued.
 ##
 ## Functions
 ## ---------

--- a/environment/bin/xfpull
+++ b/environment/bin/xfpull
@@ -1,8 +1,12 @@
 #!/bin/bash
-
 ##---------------------------------------------------------------------------##
-## Transfer 2.0 (Mercury replacement)
-## Ref: http://transfer.lanl.gov
+## File  : environment/bin/xfpull
+## Date  : Tuesday, May 31, 2016, 14:48 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##
+## Transfer 2.0 (Mercury replacement), Ref: http://transfer.lanl.gov
 ##
 ## Examples:
 ##   xfpush foo.txt

--- a/environment/bin/xfpush
+++ b/environment/bin/xfpush
@@ -1,8 +1,12 @@
 #!/bin/bash
-
 ##---------------------------------------------------------------------------##
-## Transfer 2.0 (Mercury replacement)
-## Ref: http://transfer.lanl.gov
+## File  : environment/bin/xfpush
+## Date  : Tuesday, May 31, 2016, 14:48 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##
+## Transfer 2.0 (Mercury replacement), Ref: http://transfer.lanl.gov
 ##
 ## Examples:
 ##   xfpush foo.txt
@@ -22,4 +26,3 @@ for myfile in $myfiles; do
     echo scp $myfile red@transfer.lanl.gov:
 done
 IFS=$saveifs
-

--- a/environment/cshrc/.cshrc
+++ b/environment/cshrc/.cshrc
@@ -1,4 +1,11 @@
 #!/bin/csh
+##---------------------------------------------------------------------------##
+## File  : environment/cshrc/.cshrc
+## Date  : Tuesday, May 31, 2016, 14:48 pm
+## Author: Kelly Thompson
+## Note  : Copyright (C) 2016, Los Alamos National Security, LLC.
+##         All rights are reserved.
+##---------------------------------------------------------------------------##
 
 # Use: In ~/.cshrc add the following code:
 #
@@ -43,8 +50,12 @@ case ml-fey*.lanl.gov:
 case ml*.localdomain:
 case lu*.lanl.gov:
 case lu*.localdomain:
+case sn*:
+case fi*:
+case ic*:
     setenv VENDOR_DIR /usr/projects/draco/vendors
     module load friendly-testing user_contrib
+    module load clang-format
     module load intel/17.0.1 openmpi/1.10.3 mkl
     module load git subversion emacs grace
     module load cmake/3.6.2 numdiff random123 eospac/6.2.4
@@ -72,6 +83,7 @@ case tr*:
     module unload PrgEnv-intel PrgEnv-pgi
     module unload cmake numdiff svn gsl
     module unload papi perftools
+    module load clang-format
 
     # load the Intel programming env, but then unloda libsci and totalview
     module load PrgEnv-intel # this loads xt-libsci and intel/XXX


### PR DESCRIPTION
+ `clang-format/3.9.0` is now available on all HPC machines and will be loaded with the default Draco environment. Please consider installing the git pre-commit hook (`draco/environment/git/install-hooks.sh`) for all of your CCS-2 git repositories.
  - `.bashrc` files updated
  - `.cshrc` file updated
+ Add snow, fire and ice to the `.cshrc`.
+ Cosmetic changes
  - Add header blocks to some bash scripts.
  - Fix a filename typo in `doxygen_config`.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
