### PR TITLE
Modify scripts to find capsaicin on gitlab instead of subversion.

### DIFF
--- a/autodoc/mainpage.dcc.in
+++ b/autodoc/mainpage.dcc.in
@@ -10,14 +10,22 @@
 \par Authors
 <a href="mailto:kgt@lanl.gov">Kelly (KT) Thompson</a>,
 <a href="mailto:kgb@lanl.gov">Kent Budge</a>,
-<a href="mailto:lowrie@lanl.gov">Robert Lowrie</a>,
-<a href="mailto:gaber@lanl.gov">Gabe Rockefeller</a>,
-<a href="mailto:warsa@lanl.gov">Jim Warsa</a>,
-<a href="mailto:wollaber@lanl.gov">Allan Wollaber</a>,
 <a href="mailto:jhchang@lanl.gov">Jae Chang</a>
+<a href="mailto:lowrie@lanl.gov">Robert Lowrie</a>,
+<a href="mailto:warsa@lanl.gov">Jim Warsa</a>,
+<a href="mailto:@lanl.gov">Alex Long</a>,
+<a href="mailto:@lanl.gov">Matt Cleveland</a>,
+<a href="mailto:@lanl.gov">Massimiliano Rosa</a>,
+<a href="mailto:@lanl.gov">Kendra Keady</a>,
+<a href="mailto:@lanl.gov">Andrew Till</a>,
+<a href="mailto:@lanl.gov">Ryan Wollaeger</a>,
+<a href="mailto:@lanl.gov">Kris Garrett</a>,
 
 \par Former contributors
-Tom Evans, Todd Adams, John McGhee, Mike Buksas, Randy Roberts, Seth Johnson, Paul Talbot, Jeff Furnish, Paul Henning.
+
+Jeff Densmore, Lori Pritchett-Sheats, Katherine Wang, Gabe Rockefeller, Allan
+Wollaber, Tom Evans, Todd Adams, John McGhee, Mike Buksas, Randy Roberts, Seth
+Johnson, Paul Talbot, Jeff Furnish, Paul Henning, Nick Meyers.
 
 \par Executive Summary
 Draco is a C++ radiation transport component library developed by CCS-2, Los

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -753,16 +753,10 @@ macro(set_pkg_work_dir this_pkg dep_pkg)
     string( REPLACE "intel-perfbench" "icpc" ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     # string( REPLACE "-belosmods"      ""     ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
 
-    if( "${this_pkg}" MATCHES "jayenne" )
+    if( "${this_pkg}" MATCHES "jayenne" OR "${this_pkg}" MATCHES "capsaicin")
       # If this is jayenne, we might be building a pull request. Replace the PR
       # number in the path with '-develop' before looking for draco.
       string( REGEX REPLACE "(Nightly|Experimental|Continuous)_(.*)(-pr[0-9]+)/" "\\1_\\2-develop/"
-        ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
-    endif()
-
-    if( "${this_pkg}" MATCHES "capsaicin" )
-      # Probably building capsaicin, append '-develop' when looking for draco.
-      string( REGEX REPLACE "(Nightly|Experimental|Continuous)_(.*)/" "\\1_\\2-develop/"
         ${dep_pkg}_work_dir ${${dep_pkg}_work_dir} )
     endif()
   endif()

--- a/regression/pull_repositories_xf.sh
+++ b/regression/pull_repositories_xf.sh
@@ -130,7 +130,7 @@ unpack_repo_git() {
 #------------------------------------------------------------------------------#
 # working directory
 start_dir=`pwd`
-work_dir=/usr/projects/draco/svn
+work_dir=/usr/projects/draco/git
 if test -d $work_dir; then
    run "cd $work_dir"
 else
@@ -151,21 +151,21 @@ jayenne_ready=0
 draco_git_ready=0
 
 for item in $possible_items_to_pull; do
-   if test ${item} = "capsaicin.hotcopy.tar"; then capsaicin_ready=1; fi
-   if test ${item} = "Draco.git.tar";         then draco_git_ready=1; fi
-   if test ${item} = "jayenne.git.tar";       then jayenne_ready=1; fi
+   if test ${item} = "capsaicin.git.tar"; then capsaicin_ready=1; fi
+   if test ${item} = "Draco.git.tar";     then draco_git_ready=1; fi
+   if test ${item} = "jayenne.git.tar";   then jayenne_ready=1;   fi
 done
 
 # If found, pull the files
-if test ${capsaicin_ready} = 1; then unpack_repo "capsaicin"; fi
-run "cd ${work_dir}/../git"
+run "cd ${work_dir}"
 if test ${draco_git_ready} = 1; then unpack_repo_git "Draco.git"; fi
 if test ${jayenne_ready} = 1; then unpack_repo_git "jayenne.git"; fi
+if test ${capsaicin_ready} = 1; then unpack_repo "capsaicin.git"; fi
 
 # Update permisssions as needed
 run "cd ${work_dir}/.."
-run "chgrp -R draco svn git"
-run "chmod -R g+rwX,o-rwX svn git"
+run "chgrp -R draco git"
+run "chmod -R g+rwX,o-rwX git"
 
 # Modules
 # ----------------------------------------

--- a/regression/regression-master.sh
+++ b/regression/regression-master.sh
@@ -383,14 +383,15 @@ if test `echo $projects | grep -c $subproj` -gt 0; then
 fi
 
 # Only Draco is on github, other projects still use svn.
-unset featurebranch
-unset fb
-unset ifb
-unset prdash
-unset USE_GITHUB
+#unset featurebranch
+#unset fb
+#unset ifb
+#unset prdash
+#unset USE_GITHUB
 
 export subproj=capsaicin
 if test `echo $projects | grep -c $subproj` -gt 0; then
+  export featurebranch=${fb[$ifb]}
   cmd="${rscriptdir}/${machine_name_short}-job-launch.sh"
   # Wait for draco regressions to finish
   case $extra_params in
@@ -401,11 +402,12 @@ if test `echo $projects | grep -c $subproj` -gt 0; then
   *)
      cmd+=" ${draco_jobid}" ;;
   esac
-  cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}-joblaunch.log"
+  cmd+=" &> ${logdir}/${machine_name_short}-${subproj}-${build_type}${epdash}${extra_params}${prdash}${featurebranch}-joblaunch.log"
   echo "${subproj}: $cmd"
   eval "${cmd} &"
   sleep 1
   capsaicin_jobid=`jobs -p | sort -gr | head -n 1`
+  ((ifb++))
 fi
 
 # Wait for all parallel jobs to finish

--- a/regression/scripts/common.sh
+++ b/regression/scripts/common.sh
@@ -11,7 +11,7 @@ function run () {
   if test ${dry_run:-no} = "no"; then eval $1; fi
 }
 
-fn_exists()
+function fn_exists()
 {
     type $1 2>/dev/null | grep -q 'is a function'
     res=$?

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -334,6 +334,11 @@ for prline in $jayenne_prs $capsaicin_prs; do
   # the existing draco build.  Additionally, if two PRs are started at the same
   # time, only build draco for the 1st one.
   if [[ $midnight -gt $draco_last_built ]] && [[ $ipr == 0 ]]; then
+
+    echo " "
+    echo "Found a Jayenne or Capsaicin PR, but we need to build draco-develop first..."
+    echo " "
+
     projects="draco"
     featurebranches="develop"
 
@@ -345,13 +350,13 @@ for prline in $jayenne_prs $capsaicin_prs; do
 
       # CCS-NET: Coverage (Debug) & Valgrind (Debug)
       ccscs*)
-        logfile=$regdir/logs/ccscs-jayenne-Debug-coverage-master-develop.log
+        logfile=$regdir/logs/ccscs-draco-Debug-coverage-master-develop.log
         echo "- Starting regression (coverage) for develop."
         echo "  Log: $logfile"
         $regdir/draco/regression/regression-master.sh -r -b Debug -e coverage \
           -p "${projects}" &> $logfile &
 
-        logfile=$regdir/logs/ccscs-jayenne-Debug-valgrind-master-develop.log
+        logfile=$regdir/logs/ccscs-draco-Debug-valgrind-master-develop.log
         echo "- Starting regression (valgrind) for develop."
         echo "  Log: $logfile"
         $regdir/draco/regression/regression-master.sh -r -b Debug -e valgrind \

--- a/regression/sync_repository.sh
+++ b/regression/sync_repository.sh
@@ -150,6 +150,24 @@ else
   run "cd $gitroot"
   run "git clone --bare git@github.com:losalamos/Draco.git Draco.git"
 fi
+case ${target} in
+  ccscs7*)
+    # Keep a copy of the bare repo for Redmine.  This version doesn't have the
+    # PRs since this seems to confuse Redmine.
+    echo " "
+    echo "(Redmine) Copy Draco git repository to the local file system..."
+    if test -d $gitroot/Draco-redmine.git; then
+      run "cd $gitroot/Draco-redmine.git"
+      run "git fetch origin +refs/heads/*:refs/heads/*"
+      run "git reset --soft"
+    else
+      run "mkdir -p $gitroot"
+      run "cd $gitroot"
+      run "git clone --bare git@github.com:losalamos/Draco.git Draco-redmine.git"
+    fi
+    ;;
+esac
+
 
 # JAYENNE: For all machines running this scirpt, copy all of the git repositories
 # to the local file system.
@@ -173,22 +191,18 @@ case ${target} in
     # Keep a copy of the bare repo for Redmine.  This version doesn't have the
     # PRs since this seems to confuse Redmine.
     echo " "
-    echo "(Redmine) Copy Draco git repository to the local file system..."
-    if test -d $gitroot/Draco.git; then
-      run "cd $gitroot/Draco-redmine.git"
-      run "git fetch origin +refs/heads/*:refs/heads/*"
-      run "git reset --soft"
-    fi
-    echo " "
     echo "(Redmine) Copy Jayenne git repository to the local file system..."
-    if test -d $gitroot/jayenne.git; then
+    if test -d $gitroot/jayenne-redmine.git; then
       run "cd $gitroot/jayenne-redmine.git"
       run "git fetch origin +refs/heads/*:refs/heads/*"
       run "git reset --soft"
+    else
+      run "mkdir -p $gitroot"
+      run "cd $gitroot"
+      run "git clone --bare git@gitlab.lanl.gov:jayenne/jayenne.git jayenne-redmine.git"
     fi
     ;;
 esac
-
 
 # CAPSAICIN: For all machines running this scirpt, copy all of the git repositories
 # to the local file system.
@@ -212,18 +226,15 @@ case ${target} in
     # Keep a copy of the bare repo for Redmine.  This version doesn't have the
     # PRs since this seems to confuse Redmine.
     echo " "
-    echo "(Redmine) Copy Draco git repository to the local file system..."
-    if test -d $gitroot/Draco.git; then
-      run "cd $gitroot/Draco-redmine.git"
-      run "git fetch origin +refs/heads/*:refs/heads/*"
-      run "git reset --soft"
-    fi
-    echo " "
     echo "(Redmine) Copy Capsaicin git repository to the local file system..."
-    if test -d $gitroot/capsaicin.git; then
+    if test -d $gitroot/capsaicin-redmine.git; then
       run "cd $gitroot/capsaicin-redmine.git"
       run "git fetch origin +refs/heads/*:refs/heads/*"
       run "git reset --soft"
+    else
+      run "mkdir -p $gitroot"
+      run "cd $gitroot"
+      run "git clone --bare git@gitlab.lanl.gov:capsaicin/capsaicin.git capsaicin-redmine.git"
     fi
     ;;
 esac

--- a/regression/update_regression_scripts.sh
+++ b/regression/update_regression_scripts.sh
@@ -25,10 +25,6 @@ case ${target} in
     VENDOR_DIR=/usr/projects/draco/vendors
     # personal copy of ssh-agent.
     export PATH=$HOME/bin:$PATH
-    if test -d /projects/opt/centos7/subversion/1.9.2/bin; then
-      export PATH=/projects/opt/centos7/subversion/1.9.2/bin:$PATH
-    fi
-    SVN=`which svn`
     export http_proxy=http://proxyout.lanl.gov:8080;
     export https_proxy=$http_proxy;
     export HTTP_PROXY=$http_proxy;
@@ -43,18 +39,13 @@ case ${target} in
     if ! [[ $MODULESHOME ]]; then
        source /usr/share/Modules/init/bash
     fi
-    run "module load user_contrib subversion"
-    SVN=`which svn`
     ;;
   ml-*)
     REGDIR=/usr/projects/jayenne/regress
     keychain=keychain-2.7.1
     VENDOR_DIR=/usr/projects/draco/vendors
-    SVN=/usr/projects/hpcsoft/toss2/common/subversion/1.9.1/bin/svn
     ;;
   *)
-    # module load user_contrib subversion
-    SVN=/scratch/vendors/subversion-1.9.3/bin/svn
     REGDIR=/scratch/regress
     ;;
 esac
@@ -106,11 +97,10 @@ fi
 # Capsaicin
 echo " "
 echo "Updating $REGDIR/capsaicin..."
-if test -d ${REGDIR}/capsaicin/scripts; then
-run "cd ${REGDIR}/capsaicin/scripts; ${SVN} update"
+if test -d ${REGDIR}/capsaicin; then
+  run "cd ${REGDIR}/capsaicin; git pull"
 else
-  run "mkdir -p ${REGDIR}/capsaicin; cd ${REGDIR}/capsaicin"
-  run "${SVN} co svn+ssh://ccscs7.lanl.gov/ccs/codes/radtran/svn/capsaicin/trunk/scripts"
+  run "cd ${REGDIR}; git clone git@gitlab.lanl.gov:capsaicin/capsaicin.git"
 fi
 
 ##---------------------------------------------------------------------------##

--- a/src/ds++/Release.cc
+++ b/src/ds++/Release.cc
@@ -114,7 +114,7 @@ const std::string author_list() {
 
   mmdevs prior_developers;
 
-  prior_developers.insert( fomdev(4451,"Jeff D. Densmore"));
+  prior_developers.insert(fomdev(4451, "Jeff D. Densmore"));
   prior_developers.insert(fomdev(1160, "Allan B. Wollaber"));
   prior_developers.insert(fomdev(995, "Lori A. Pritchett-Sheats"));
   prior_developers.insert(fomdev(774, "Katherine J. Wang"));
@@ -122,6 +122,9 @@ const std::string author_list() {
   prior_developers.insert(fomdev(470, "Paul W. Talbot"));
   // < 100 lines
   // prior_developers.insert(fomdev(44, "Nick Myers"));
+
+  // Tom Evans, Todd Adams, John McGhee, Mike Buksas, Randy Roberts, Seth
+  // Johnson, Jeff Furnish, Paul Henning
 
   size_t const maxlinelen(80);
   std::string line_name("CCS-2 Draco Team: ");


### PR DESCRIPTION
+ In `draco_regression_macros.cmake`, remove special code used to find Draco from the Capsaicin regression scripts.  Both Jayenne and Capsaicin will use the same logic now.
+ In `push_repositories_xf.sh`, remove the svn-specific coding. We only need to work with git repositories now.
+ In `sync_repository.sh` and `update_regression_scripts.sh` remove code related to subversion. Copy jayenne blocks and repurpose them for capsaicin.
+ Cosmetic changes to `Release.cc` and `mainpage.dcc.in`.
+ refs [#834](https://rtt.lanl.gov/redmine/issues/834)
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
