### PR TITLE
Remove quotes to prevent cmake from treating a list of files as a lon…

### DIFF
--- a/src/diagnostics/qt/CMakeLists.txt
+++ b/src/diagnostics/qt/CMakeLists.txt
@@ -79,7 +79,7 @@ add_component_executable(
 if (WIN32)
   file( GLOB qtdlls ${QTDIR}/bin/*.dll )
   add_custom_command( TARGET Exe_draco_info_gui POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${qtdlls}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${qtdlls}
             $<TARGET_FILE_DIR:Exe_draco_info_gui>
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Lib_dsxx>
             $<TARGET_FILE_DIR:Exe_draco_info_gui>


### PR DESCRIPTION
* Remove quotes to prevent cmake from treating a list of files as a long filename.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [ ] Travis CI checks pass
  * [ ] Code coverage does not decrease
  * [ ] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
