### PR TITLE
Add optional context argument to parse_class template function.

### DIFF
--- a/src/parser/Class_Parse_Table.hh
+++ b/src/parser/Class_Parse_Table.hh
@@ -165,6 +165,60 @@ parse_class_from_table(Token_Stream &tokens) {
   }
 }
 
+//---------------------------------------------------------------------------------------//
+/*! Template for helper function that produces a class object.
+ *
+ * \param tokens Token stream from which to parse the user input.
+ *
+ * \param context A context object that controls the behavior of the parser. This is passed
+ * to the constructor for the Class_Parse_Table.
+ *
+ * \return A pointer to an object matching the user specification, or NULL if
+ * the specification is not valid.
+ */
+
+template <class Class_Parse_Table>
+SP<typename Class_Parse_Table::Return_Class> parse_class_from_table(
+    Token_Stream &tokens,
+    typename Class_Parse_Table::Context_Type const &context) {
+  using rtt_parser::Token;
+  using rtt_parser::END;
+  using rtt_parser::EXIT;
+
+  typedef typename Class_Parse_Table::Return_Class Return_Class;
+
+  // Construct the parse object as described above.
+  Class_Parse_Table parse_table(context);
+
+  // Save the old error count, so we can distinguish fresh errors within
+  // this class keyword block from previous errors.
+  unsigned const old_error_count = tokens.error_count();
+
+  // Parse the class keyword block and check for completeness
+  Token const terminator = parse_table.parse_table().parse(tokens);
+  bool allow_exit = parse_table.allow_exit(); // improve code coverage
+  if (terminator.type() == END || (allow_exit && terminator.type() == EXIT))
+  // A class keyword block is expected to end with an END or (if
+  // allow_exit is true) an EXIT.
+  {
+    parse_table.check_completeness(tokens);
+
+    SP<Return_Class> Result;
+    if (tokens.error_count() == old_error_count) {
+      // No fresh errors in the class keyword block.  Create the object.
+      Result = parse_table.create_object();
+    }
+    // else there were errors in the keyword block. Don't try to
+    // create a class object.  Return the null pointer.
+
+    return Result;
+  } else {
+    tokens.report_syntax_error("missing 'end'?");
+    return SP<Return_Class>();
+    // never reached; to eliminate spurious warning.
+  }
+}
+
 } // end namespace rtt_parser
 
 #endif // parser_Class_Parse_Table_hh

--- a/src/parser/Class_Parse_Table.hh
+++ b/src/parser/Class_Parse_Table.hh
@@ -174,10 +174,9 @@ parse_class_from_table(Token_Stream &tokens) {
  * the specification is not valid.
  */
 
-template <class Class_Parse_Table>
-SP<typename Class_Parse_Table::Return_Class> parse_class_from_table(
-    Token_Stream &tokens,
-    typename Class_Parse_Table::Context_Type const &context) {
+template <typename Class_Parse_Table, typename Context>
+SP<typename Class_Parse_Table::Return_Class>
+parse_class_from_table(Token_Stream &tokens, Context const &context) {
   using rtt_parser::Token;
   using rtt_parser::END;
   using rtt_parser::EXIT;

--- a/src/parser/Class_Parse_Table.hh
+++ b/src/parser/Class_Parse_Table.hh
@@ -143,26 +143,23 @@ parse_class_from_table(Token_Stream &tokens) {
   // Parse the class keyword block and check for completeness
   Token const terminator = parse_table.parse_table().parse(tokens);
   bool allow_exit = parse_table.allow_exit(); // improve code coverage
+  SP<Return_Class> Result;
   if (terminator.type() == END || (allow_exit && terminator.type() == EXIT))
   // A class keyword block is expected to end with an END or (if
   // allow_exit is true) an EXIT.
   {
     parse_table.check_completeness(tokens);
 
-    SP<Return_Class> Result;
     if (tokens.error_count() == old_error_count) {
       // No fresh errors in the class keyword block.  Create the object.
       Result = parse_table.create_object();
     }
     // else there were errors in the keyword block. Don't try to
     // create a class object.  Return the null pointer.
-
-    return Result;
   } else {
     tokens.report_syntax_error("missing 'end'?");
-    return SP<Return_Class>();
-    // never reached; to eliminate spurious warning.
   }
+  return Result;
 }
 
 //---------------------------------------------------------------------------------------//
@@ -197,26 +194,24 @@ SP<typename Class_Parse_Table::Return_Class> parse_class_from_table(
   // Parse the class keyword block and check for completeness
   Token const terminator = parse_table.parse_table().parse(tokens);
   bool allow_exit = parse_table.allow_exit(); // improve code coverage
+  SP<Return_Class> Result;
   if (terminator.type() == END || (allow_exit && terminator.type() == EXIT))
   // A class keyword block is expected to end with an END or (if
   // allow_exit is true) an EXIT.
   {
     parse_table.check_completeness(tokens);
 
-    SP<Return_Class> Result;
     if (tokens.error_count() == old_error_count) {
       // No fresh errors in the class keyword block.  Create the object.
       Result = parse_table.create_object();
     }
     // else there were errors in the keyword block. Don't try to
     // create a class object.  Return the null pointer.
-
-    return Result;
   } else {
     tokens.report_syntax_error("missing 'end'?");
-    return SP<Return_Class>();
-    // never reached; to eliminate spurious warning.
   }
+
+  return Result;
 }
 
 } // end namespace rtt_parser

--- a/src/parser/test/tstClass_Parser.cc
+++ b/src/parser/test/tstClass_Parser.cc
@@ -161,6 +161,28 @@ void tstClass_Parser(UnitTest &ut) {
   ut.check(dummy, "parsed the indolent class object", true);
   ut.check(dummy->Get_Insouciance() == -3.3,
            "parsed the indolent insouciance correctly");
+
+  // Test that missing end is caught.
+
+  text = "insouciance = 3.3\n";
+  String_Token_Stream etokens(text);
+
+  bool good = false;
+  try {
+    SP<DummyClass> dummy = parse_class<DummyClass>(etokens);
+  } catch (Syntax_Error &) {
+    good = true;
+  }
+  ut.check(good, "catches missing end");
+
+  tokens.rewind();
+  good = false;
+  try {
+    SP<DummyClass> dummy = parse_class<DummyClass>(etokens, true);
+  } catch (Syntax_Error &) {
+    good = true;
+  }
+  ut.check(good, "indolent catches missing end");
 }
 
 //---------------------------------------------------------------------------------------//

--- a/src/parser/test/tstClass_Parser.cc
+++ b/src/parser/test/tstClass_Parser.cc
@@ -1,4 +1,4 @@
-//----------------------------------*-C++-*----------------------------------//
+//----------------------------------*-C++-*----------------------------------------------//
 /*!
  * \file   parser/test/tstClass_Parser.cc
  * \author Kent Budge
@@ -6,9 +6,9 @@
  * \note   Copyright (C) 2016 Los Alamos National Security, LLC.
  *         All rights reserved.
  */
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 // $Id$
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
@@ -20,12 +20,10 @@ using namespace std;
 using namespace rtt_dsxx;
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 class DummyClass {
 public:
-  DummyClass(double const insouciance) : insouciance(insouciance) {
-    Require(insouciance >= 0.0);
-  }
+  DummyClass(double const insouciance) : insouciance(insouciance) {}
 
   double Get_Insouciance() const { return insouciance; }
 
@@ -34,16 +32,17 @@ private:
 };
 
 namespace rtt_parser {
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 template <> class Class_Parse_Table<DummyClass> {
 public:
   // TYPEDEFS
 
   typedef DummyClass Return_Class;
+  typedef bool Context_Type;
 
   // MANAGEMENT
 
-  Class_Parse_Table();
+  Class_Parse_Table(bool is_indolent = false);
 
   // SERVICES
 
@@ -60,6 +59,8 @@ protected:
 
   double parsed_insouciance;
 
+  bool is_indolent;
+
 private:
   // IMPLEMENTATION
 
@@ -72,31 +73,43 @@ private:
   static bool parse_table_is_initialized_;
 };
 
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 Class_Parse_Table<DummyClass> *Class_Parse_Table<DummyClass>::current_;
 Parse_Table Class_Parse_Table<DummyClass>::parse_table_;
 bool Class_Parse_Table<DummyClass>::parse_table_is_initialized_ = false;
 
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 template <> SP<DummyClass> parse_class<DummyClass>(Token_Stream &tokens) {
   return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens);
 }
 
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
+template <>
+SP<DummyClass> parse_class<DummyClass>(Token_Stream &tokens,
+                                       bool const &is_indolent) {
+  return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens,
+                                                               is_indolent);
+}
+
+//---------------------------------------------------------------------------------------//
 void Class_Parse_Table<DummyClass>::parse_insouciance_(Token_Stream &tokens,
                                                        int) {
-  if (current_->parsed_insouciance >= 0.0) {
-    tokens.report_semantic_error("duplicate specification of insouciance");
-  }
+  tokens.check_semantics(current_->parsed_insouciance < 0.0,
+                         "duplicate specification of insouciance");
+
   current_->parsed_insouciance = parse_real(tokens);
   if (current_->parsed_insouciance < 0) {
     tokens.report_semantic_error("insouciance must be nonnegative");
     current_->parsed_insouciance = 1;
   }
+
+  if (current_->is_indolent) {
+    current_->parsed_insouciance = -current_->parsed_insouciance;
+  }
 }
 
-//---------------------------------------------------------------------------//
-Class_Parse_Table<DummyClass>::Class_Parse_Table()
+//---------------------------------------------------------------------------------------//
+Class_Parse_Table<DummyClass>::Class_Parse_Table(bool const is_indolent)
     : parsed_insouciance(-1.0) // sentinel value
 {
   if (!parse_table_is_initialized_) {
@@ -109,17 +122,19 @@ Class_Parse_Table<DummyClass>::Class_Parse_Table()
 
     parse_table_is_initialized_ = true;
   }
+
+  this->is_indolent = is_indolent;
+
   current_ = this;
 }
 
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 void Class_Parse_Table<DummyClass>::check_completeness(Token_Stream &tokens) {
-  if (parsed_insouciance < 0) {
-    tokens.report_semantic_error("insouciance was not specified");
-  }
+  tokens.check_semantics(is_indolent || parsed_insouciance >= 0,
+                         "insouciance was not specified");
 }
 
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 SP<DummyClass> Class_Parse_Table<DummyClass>::create_object() {
   SP<DummyClass> Result = SP<DummyClass>(new DummyClass(parsed_insouciance));
   return Result;
@@ -127,9 +142,9 @@ SP<DummyClass> Class_Parse_Table<DummyClass>::create_object() {
 
 } // namespace rtt_parser
 
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 // TESTS
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 
 void tstClass_Parser(UnitTest &ut) {
   string text = "insouciance = 3.3\nend\n";
@@ -137,21 +152,18 @@ void tstClass_Parser(UnitTest &ut) {
 
   SP<DummyClass> dummy = parse_class<DummyClass>(tokens);
 
-  if (dummy != SP<DummyClass>()) {
-    ut.passes("parsed the class object");
+  ut.check(dummy, "parsed the class object", true);
+  ut.check(dummy->Get_Insouciance() == 3.3, "parsed the insouciance correctly");
 
-    if (dummy->Get_Insouciance() == 3.3) {
-      ut.passes("parsed the insouciance correctly");
-    } else {
-      ut.failure("did NOT parse the insouciance correctly");
-    }
-  } else {
-    cout << tokens.messages() << endl;
-    ut.failure("did NOT parse the class object");
-  }
+  tokens.rewind();
+  dummy = parse_class<DummyClass>(tokens, true);
+
+  ut.check(dummy, "parsed the indolent class object", true);
+  ut.check(dummy->Get_Insouciance() == -3.3,
+           "parsed the indolent insouciance correctly");
 }
 
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 
 int main(int argc, char *argv[]) {
   ScalarUnitTest ut(argc, argv, release);
@@ -161,6 +173,6 @@ int main(int argc, char *argv[]) {
   UT_EPILOG(ut);
 }
 
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 // end of tstClass_Parser.cc
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//

--- a/src/parser/test/tstClass_Parser.cc
+++ b/src/parser/test/tstClass_Parser.cc
@@ -1,4 +1,4 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   parser/test/tstClass_Parser.cc
  * \author Kent Budge
@@ -6,9 +6,9 @@
  * \note   Copyright (C) 2016 Los Alamos National Security, LLC.
  *         All rights reserved.
  */
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // $Id$
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 
 #include "ds++/Release.hh"
 #include "ds++/ScalarUnitTest.hh"
@@ -20,7 +20,7 @@ using namespace std;
 using namespace rtt_dsxx;
 using namespace rtt_parser;
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 class DummyClass {
 public:
   DummyClass(double const insouciance) : insouciance(insouciance) {}
@@ -32,13 +32,12 @@ private:
 };
 
 namespace rtt_parser {
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 template <> class Class_Parse_Table<DummyClass> {
 public:
   // TYPEDEFS
 
   typedef DummyClass Return_Class;
-  typedef bool Context_Type;
 
   // MANAGEMENT
 
@@ -73,17 +72,17 @@ private:
   static bool parse_table_is_initialized_;
 };
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 Class_Parse_Table<DummyClass> *Class_Parse_Table<DummyClass>::current_;
 Parse_Table Class_Parse_Table<DummyClass>::parse_table_;
 bool Class_Parse_Table<DummyClass>::parse_table_is_initialized_ = false;
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 template <> SP<DummyClass> parse_class<DummyClass>(Token_Stream &tokens) {
   return parse_class_from_table<Class_Parse_Table<DummyClass>>(tokens);
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 template <>
 SP<DummyClass> parse_class<DummyClass>(Token_Stream &tokens,
                                        bool const &is_indolent) {
@@ -91,7 +90,7 @@ SP<DummyClass> parse_class<DummyClass>(Token_Stream &tokens,
                                                                is_indolent);
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 void Class_Parse_Table<DummyClass>::parse_insouciance_(Token_Stream &tokens,
                                                        int) {
   tokens.check_semantics(current_->parsed_insouciance < 0.0,
@@ -108,7 +107,7 @@ void Class_Parse_Table<DummyClass>::parse_insouciance_(Token_Stream &tokens,
   }
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 Class_Parse_Table<DummyClass>::Class_Parse_Table(bool const is_indolent)
     : parsed_insouciance(-1.0) // sentinel value
 {
@@ -128,13 +127,13 @@ Class_Parse_Table<DummyClass>::Class_Parse_Table(bool const is_indolent)
   current_ = this;
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 void Class_Parse_Table<DummyClass>::check_completeness(Token_Stream &tokens) {
   tokens.check_semantics(is_indolent || parsed_insouciance >= 0,
                          "insouciance was not specified");
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 SP<DummyClass> Class_Parse_Table<DummyClass>::create_object() {
   SP<DummyClass> Result = SP<DummyClass>(new DummyClass(parsed_insouciance));
   return Result;
@@ -142,9 +141,9 @@ SP<DummyClass> Class_Parse_Table<DummyClass>::create_object() {
 
 } // namespace rtt_parser
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // TESTS
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 
 void tstClass_Parser(UnitTest &ut) {
   string text = "insouciance = 3.3\nend\n";
@@ -185,7 +184,7 @@ void tstClass_Parser(UnitTest &ut) {
   ut.check(good, "indolent catches missing end");
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 
 int main(int argc, char *argv[]) {
   ScalarUnitTest ut(argc, argv, release);
@@ -195,6 +194,6 @@ int main(int argc, char *argv[]) {
   UT_EPILOG(ut);
 }
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of tstClass_Parser.cc
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//

--- a/src/parser/utilities.hh
+++ b/src/parser/utilities.hh
@@ -1,4 +1,4 @@
-//----------------------------------*-C++-*----------------------------------//
+//----------------------------------*-C++-*----------------------------------------------//
 /*!
  * \file   parser/utilities.hh
  * \author Kent G. Budge
@@ -9,7 +9,7 @@
  * This file declares functions that parse certain common constructs in a
  * uniform way.
  */
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 
 #ifndef parser_utilities_hh
 #define parser_utilities_hh
@@ -74,7 +74,7 @@ DLL_PUBLIC_parser SP<Expression>
 parse_temperature(Token_Stream &, unsigned number_of_variables,
                   std::map<string, pair<unsigned, Unit>> const &);
 
-//----------------------------------------------------------------------------//
+//----------------------------------------------------------------------------------------//
 /*! Template for parse function that produces a class object.
  *
  * The parse_class template function is intended for general use as a common
@@ -97,11 +97,32 @@ parse_temperature(Token_Stream &, unsigned number_of_variables,
  */
 template <typename Class> rtt_dsxx::SP<Class> parse_class(Token_Stream &tokens);
 
+//----------------------------------------------------------------------------------------//
+/*! Template for parse function that produces a class object.
+ *
+ * This function resembles the previous one, but takes a second argument supply a context
+ * that may alter the parser behavior..
+ *
+ * \param tokens Token stream from which to parse the user input.
+ *
+ * \param context Context for the parse.
+ *
+ * \return A pointer to an object matching the user specification, or NULL if
+ * the specification is not valid.
+ */
+
+template <typename Class> class Class_Parse_Table;
+
+template <typename Class>
+rtt_dsxx::SP<Class>
+parse_class(Token_Stream &tokens,
+            typename Class_Parse_Table<Class>::Context_Type const &context);
+
 } // rtt_parser
 
 #endif
 // parser_utilities_hh
 
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//
 // end of utilities.hh
-//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------//

--- a/src/parser/utilities.hh
+++ b/src/parser/utilities.hh
@@ -1,4 +1,4 @@
-//----------------------------------*-C++-*----------------------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 /*!
  * \file   parser/utilities.hh
  * \author Kent G. Budge
@@ -9,7 +9,7 @@
  * This file declares functions that parse certain common constructs in a
  * uniform way.
  */
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 
 #ifndef parser_utilities_hh
 #define parser_utilities_hh
@@ -74,7 +74,7 @@ DLL_PUBLIC_parser SP<Expression>
 parse_temperature(Token_Stream &, unsigned number_of_variables,
                   std::map<string, pair<unsigned, Unit>> const &);
 
-//----------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*! Template for parse function that produces a class object.
  *
  * The parse_class template function is intended for general use as a common
@@ -97,7 +97,7 @@ parse_temperature(Token_Stream &, unsigned number_of_variables,
  */
 template <typename Class> rtt_dsxx::SP<Class> parse_class(Token_Stream &tokens);
 
-//----------------------------------------------------------------------------------------//
+//----------------------------------------------------------------------------//
 /*! Template for parse function that produces a class object.
  *
  * This function resembles the previous one, but takes a second argument supply a context
@@ -111,18 +111,14 @@ template <typename Class> rtt_dsxx::SP<Class> parse_class(Token_Stream &tokens);
  * the specification is not valid.
  */
 
-template <typename Class> class Class_Parse_Table;
-
-template <typename Class>
-rtt_dsxx::SP<Class>
-parse_class(Token_Stream &tokens,
-            typename Class_Parse_Table<Class>::Context_Type const &context);
+template <typename Class, typename Context>
+rtt_dsxx::SP<Class> parse_class(Token_Stream &tokens, Context const &context);
 
 } // rtt_parser
 
 #endif
 // parser_utilities_hh
 
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
 // end of utilities.hh
-//---------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//


### PR DESCRIPTION
* Purpose of Pull Request
 
    A second signature of the parse_class template function has been added that takes a second argument of type `Class_Parse_Table::Context_Type const &`. This allows a context object of class-dependent type to be passed to the parser which may provide context to change its behavior.
    
    In a similar fashion, a second version of the parse_class_from_table template function has been added that takes a second `Class_Parse_Table::Context_Type &` argument and passes it as an argument to the `Class_Parse_Table` constructor.
    
    A test has been added to exercise this option and ensure that it works. It also illustrates how this capability is used.

* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
