### PR TITLE
Tweaks to autodoc and repo mirroring systems.

### DIFF
--- a/autodoc/CMakeLists.txt
+++ b/autodoc/CMakeLists.txt
@@ -93,6 +93,7 @@ if( DOXYGEN_FOUND )
             -Ddoxygen_latex_output=${DOXYGEN_HTML_OUTPUT}/../latex
             -Dhtmlheader=${htmlheader}
             -Dhtmlfooter=${htmlfooter}
+            -Dproject_logo=dragon.jpg
             -P "${PROJECT_SOURCE_DIR}/config/configureFileOnMake.cmake"
     DEPENDS ${DOXYGEN_OUTPUT_DIR}/${DOXYGEN_HTML_OUTPUT}/always_out_of_date.html
     # DEPENDS "${PROJECT_SOURCE_DIR}/config/doxygen_config.in"

--- a/config/doxygen_config.in
+++ b/config/doxygen_config.in
@@ -51,7 +51,7 @@ PROJECT_BRIEF          = "@project_brief@"
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = dragon.jpg
+PROJECT_LOGO           = "@project_logo@"
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is

--- a/regression/pull_repositories_xf.sh
+++ b/regression/pull_repositories_xf.sh
@@ -160,7 +160,7 @@ done
 run "cd ${work_dir}"
 if test ${draco_git_ready} = 1; then unpack_repo_git "Draco.git"; fi
 if test ${jayenne_ready} = 1; then unpack_repo_git "jayenne.git"; fi
-if test ${capsaicin_ready} = 1; then unpack_repo "capsaicin.git"; fi
+if test ${capsaicin_ready} = 1; then unpack_repo_git "capsaicin.git"; fi
 
 # Update permisssions as needed
 run "cd ${work_dir}/.."

--- a/src/cdi_ipcress/IpcressMultigroupOpacity.hh
+++ b/src/cdi_ipcress/IpcressMultigroupOpacity.hh
@@ -6,10 +6,7 @@
  * \brief  IpcressMultigroupOpacity class header file (derived from
  *         cdi/MultigroupOpacity)
  * \note   Copyright (C) 2016 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #ifndef __cdi_ipcress_IpcressMultigroupOpacity_hh__
@@ -18,11 +15,6 @@
 #include "IpcressDataTable.hh" // we have a smart pointer to a
                                // IpcressDataTable object.
 #include "cdi/MultigroupOpacity.hh"
-#include "cdi/OpacityCommon.hh"
-#include "ds++/SP.hh"
-
-#include <string>
-#include <vector>
 
 namespace rtt_cdi_ipcress {
 // -------------------- //
@@ -37,35 +29,35 @@ class IpcressDataTable;
  * \class IpcressMultigroupOpacity
  *
  * \brief IpcressMultigroupOpacity allows the client code to retrieve opacity
- *        data for a particular material.  Each IpcressOpacity object
- *        represents a specific type of data defined by five attributes: an
- *        IPCRESS File (via a IpcressFile object), a material identifier, an
- *        energy model (already selecte since this is a Multigroup Opacity
- *        class), a physics model and a reaction type.
+ *        data for a particular material. Each IpcressOpacity object represents
+ *        a specific type of data defined by five attributes: an IPCRESS File
+ *        (via a IpcressFile object), a material identifier, an energy model
+ *        (already selecte since this is a Multigroup Opacity class), a physics
+ *        model and a reaction type.
  *
- * This is a concrete class derived from cdi/MultigroupOpacity.  This class
+ * This is a concrete class derived from cdi/MultigroupOpacity. This class
  * allows to client to access the data in IPCRESS files via the Ipcress
  * libraries.
  *
- * <p> This class is designed to be used in conjuction with the CDI.  The
- * client code will create a IpcressMultigroupOpacity object and use this
- * object as an argument during the CDI instantiation.  The purpose of this
- * class is to provide a mechanism for accessing data in IPCRESS files.  The
+ * This class is designed to be used in conjuction with the CDI. The client code
+ * will create a IpcressMultigroupOpacity object and use this object as an
+ * argument during the CDI instantiation. The purpose of this class is to
+ * provide a mechanism for accessing data in IPCRESS files. The
  * IpcressMultigroupOpacity constructor expects four arguments: a hook to
  * IPCRESS data file (spIpcressFile), a material identifier, an opacity model
- * (Rosseland or Plank) and an opacity reaction specifier (total, scattering
- * or absorption).  Once constructed, this object allows the client to access
- * any data found in the IPCRESS file for that one material.  The client code
- * will need to create a separate IpcressMultigroupOpacity object for each
- * material that it needs information about. Multiple opacity objects can
- * exist per IPCRESS file.
+ * (Rosseland or Plank) and an opacity reaction specifier (total, scattering or
+ * absorption). Once constructed, this object allows the client to access any
+ * data found in the IPCRESS file for that one material. The client code will
+ * need to create a separate IpcressMultigroupOpacity object for each material
+ * that it needs information about. Multiple opacity objects can exist per
+ * IPCRESS file.
  *
- * <p> This class only provides access to multigroup opacity data.  If the
- * user needs gray opacity IPCRESS data he/she should use the
+ * This class only provides access to multigroup opacity data. If the user needs
+ * gray opacity IPCRESS data he/she should use the
  * cdi_ipcress/IpcressGrayOpacity class.
  *
- * <p> When instantiated, the IpcressMultigroupOpacity object creates a
- * IpcressDataTable object.  The IPCRESS data is cached in this table object.
+ * When instantiated, the IpcressMultigroupOpacity object creates a
+ * IpcressDataTable object. The IPCRESS data is cached in this table object.
  * When the client requests an opacity value at a specified temperature and
  * density the IpcressMultigroupOpacity object interpolates on the data cached
  * in the IpcressDataTable object.
@@ -74,18 +66,18 @@ class IpcressDataTable;
 /*!
  * \example cdi_ipcress/test/tIpcressOpacity.cc
  *
- * Example of IpcressMultigroupOpacity usage independent of CDI.  In this
- * example we construct a IpcressMultigroupOpacity object for the material
- * Aluminum (matID=10001 in our example IPCRESS file).  We then use the
+ * Example of IpcressMultigroupOpacity usage independent of CDI. In this example
+ * we construct a IpcressMultigroupOpacity object for the material Aluminum
+ * (matID=10001 in our example IPCRESS file). We then use the
  * IpcressMultigroupOpacity object to compute Rosseland Multigroup opacity
- * values for a specified material, temperature and density.  Other forms of
- * the getOpacity() accessor are tested along with accessors that return
- * information about the data set and the cached data table.
+ * values for a specified material, temperature and density. Other forms of the
+ * getOpacity() accessor are tested along with accessors that return information
+ * about the data set and the cached data table.
  *
  * \example cdi_ipcress/test/tIpcressWithCDI.cc
  *
- * This example tests and demonstrates how to use the cdi_ipcress
- * package as a plug-in for the CDI class.
+ * This example tests and demonstrates how to use the cdi_ipcress package as a
+ * plug-in for the CDI class.
  */
 //===========================================================================//
 
@@ -99,15 +91,15 @@ class DLL_PUBLIC_cdi_ipcress IpcressMultigroupOpacity
   // ----------------------- //
 
   /*!
-     * \brief The name of the ipcress data file.  This is saved for the packer
-     *         routines
-     */
+   * \brief The name of the ipcress data file.  This is saved for the packer
+   *         routines
+   */
   std::string mutable ipcressFilename;
 
   /*!
-     * \brief Identification number for one of the materials found in
-     *     the IPCRESS file pointed to by spIpcressFile.
-     */
+   * \brief Identification number for one of the materials found in the IPCRESS
+   *     file pointed to by spIpcressFile.
+   */
   size_t materialID;
 
   // -------------------- //
@@ -124,17 +116,17 @@ class DLL_PUBLIC_cdi_ipcress IpcressMultigroupOpacity
   // --------------- //
 
   /*!
-     * \brief The physics model that the current data set is based on.
-     *        { Rosseland, Plank }.  This enumeration is defined
-     *        in cdi/OpacityCommon.hh.
-     */
+   * \brief The physics model that the current data set is based on. {
+   *     Rosseland, Plank }.  This enumeration is defined in
+   *     cdi/OpacityCommon.hh.
+   */
   rtt_cdi::Model opacityModel;
 
   /*!
-     * \brief The type of reaction rates that the current data set
-     *        represents { Total, Scattering, Absorption }. This
-     *        enumeration is defined in cdi/OpacityCommon.hh.
-     */
+   * \brief The type of reaction rates that the current data set represents {
+   *     Total, Scattering, Absorption }. This enumeration is defined in
+   *     cdi/OpacityCommon.hh.
+   */
   rtt_cdi::Reaction opacityReaction;
 
   //! A string that identifies the energy policy for this class.
@@ -145,12 +137,12 @@ class DLL_PUBLIC_cdi_ipcress IpcressMultigroupOpacity
   // -------------------- //
 
   /*!
-     * \brief spIpcressDataTable contains a cached copy of the
-     *        requested IPCRESS opacity lookup table.
-     *
-     * There is a one-to-one relationship between IpcressOpacity and
-     * IpcressDataTable.
-     */
+   * \brief spIpcressDataTable contains a cached copy of the requested IPCRESS
+   *     opacity lookup table.
+   *
+   * There is a one-to-one relationship between IpcressOpacity and
+   * IpcressDataTable.
+   */
   rtt_dsxx::SP<const IpcressDataTable> spIpcressDataTable;
 
 public:
@@ -159,50 +151,48 @@ public:
   // ------------ //
 
   /*!
-     * \brief This is the default IpcressMultigroupOpacity
-     *     constructor.  It requires four arguments plus the energy
-     *     model (this class) to be instantiated.
-     *
-     *     The combiniation of a data file and a material ID uniquely
-     *     specifies a material.  If we add the Model, Reaction and
-     *     EnergyPolicy the opacity table is uniquely defined.
-     *
-     * \param spIpcressFile This smart pointer links an IPCRESS
-     *     file (via the IpcressFile object) to a IpcressOpacity
-     *     object. There may be many IpcressOpacity objects per
-     *     IpcressFile object but only one IpcressFile object for each
-     *     IpcressOpacity object.
-     * \param materialID An identifier that links the
-     *     IpcressOpacity object to a single material found in the
-     *     specified IPCRESS file.
-     * \param opacityModel The physics model that the current
-     *     data set is based on.
-     * \param opacityReaction The type of reaction rate that the
-     *     current data set represents.
-     */
+   * \brief This is the default IpcressMultigroupOpacity constructor.  It
+   *     requires four arguments plus the energy model (this class) to be
+   *     instantiated.
+   *
+   *     The combiniation of a data file and a material ID uniquely specifies a
+   *     material.  If we add the Model, Reaction and EnergyPolicy the opacity
+   *     table is uniquely defined.
+   *
+   * \param spIpcressFile This smart pointer links an IPCRESS file (via the
+   *     IpcressFile object) to a IpcressOpacity object. There may be many
+   *     IpcressOpacity objects per IpcressFile object but only one IpcressFile
+   *     object for each IpcressOpacity object.
+   * \param materialID An identifier that links the IpcressOpacity object to a
+   *     single material found in the specified IPCRESS file.
+   * \param opacityModel The physics model that the current data set is based
+   *     on.
+   * \param opacityReaction The type of reaction rate that the current data set
+   *     represents.
+   */
   IpcressMultigroupOpacity(rtt_dsxx::SP<IpcressFile const> const &spIpcressFile,
                            size_t materialID, rtt_cdi::Model opacityModel,
                            rtt_cdi::Reaction opacityReaction);
 
   /*!
-     * \brief Unpacking constructor.
-     *
-     * This constructor unpacks a IpcressMultigroupOpacity object from a
-     * state attained through the pack function.
-     *
-     * \param packed vector<char> of packed IpcressMultigroupOpacity state;
-     * the packed state is attained by calling pack()
-     */
+   * \brief Unpacking constructor.
+   *
+   * This constructor unpacks a IpcressMultigroupOpacity object from a state
+   * attained through the pack function.
+   *
+   * \param packed vector<char> of packed IpcressMultigroupOpacity state; the
+   * packed state is attained by calling pack()
+   */
   explicit IpcressMultigroupOpacity(std::vector<char> const &packed);
 
   /*!
-     * \brief Default IpcressOpacity() destructor.
-     *
-     *     This is required to correctly release memory when a
-     *     IpcressMultigroupOpacity is destroyed.  This constructor's
-     *     definition must be declared in the implementation file so
-     *     that * we can avoid including too many header files
-     */
+   * \brief Default IpcressOpacity() destructor.
+   *
+   *     This is required to correctly release memory when a
+   *     IpcressMultigroupOpacity is destroyed.  This constructor's definition
+   *     must be declared in the implementation file so that * we can avoid
+   *     including too many header files
+   */
   ~IpcressMultigroupOpacity(void){/* empty */};
 
   // --------- //
@@ -210,29 +200,28 @@ public:
   // --------- //
 
   /*!
-     * \brief Opacity accessor that utilizes STL-like iterators.  This
-     *     accessor expects a list of (temperature,density) tuples.
-     *     A set of opacity multigroup values will be returned for
-     *     each tuple.  The temperature and density iterators are
-     *     required to be the same length.  The opacity container
-     *     should have a length equal to the number of tuples times
-     *     the number of energy groups for multigroup data set.
-     *
-     * \param temperatureFirst The beginning position of a STL
-     *     container that holds a list of temperatures.
-     * \param temperatureLast The end position of a STL
-     *     container that holds a list of temperatures.
-     * \param densityFirst The beginning position of a STL
-     *     container that holds a list of densities.
-     * \param densityLast The end position of a STL
-     *     container that holds a list of temperatures.
-     * \param opacityFirst The beginning position of a STL
-     *     container into which opacity values corresponding to the
-     *     given (temperature,density) tuple will be stored.
-     * \return A list (of type OpacityIterator) of opacities are
-     *     returned.  These opacities correspond to the temperature
-     *     and density values provied in the two InputIterators.
-     */
+   * \brief Opacity accessor that utilizes STL-like iterators.  This accessor
+   *     expects a list of (temperature,density) tuples.  A set of opacity
+   *     multigroup values will be returned for each tuple.  The temperature and
+   *     density iterators are required to be the same length.  The opacity
+   *     container should have a length equal to the number of tuples times the
+   *     number of energy groups for multigroup data set.
+   *
+   * \param temperatureFirst The beginning position of a STL container that
+   *     holds a list of temperatures.
+   * \param temperatureLast The end position of a STL container that holds a
+   *     list of temperatures.
+   * \param densityFirst The beginning position of a STL container that holds a
+   *     list of densities.
+   * \param densityLast The end position of a STL container that holds a list of
+   *     temperatures.
+   * \param opacityFirst The beginning position of a STL container into which
+   *     opacity values corresponding to the given (temperature,density) tuple
+   *     will be stored.
+   * \return A list (of type OpacityIterator) of opacities are returned.  These
+   *     opacities correspond to the temperature and density values provied in
+   *     the two InputIterators.
+   */
   template <class TemperatureIterator, class DensityIterator,
             class OpacityIterator>
   OpacityIterator
@@ -241,27 +230,26 @@ public:
              DensityIterator densityLast, OpacityIterator opacityFirst) const;
 
   /*!
-     * \brief Opacity accessor that utilizes STL-like iterators.  This
-     *     accessor expects a list of temperatures in an STL
-     *     container.  A set of multigroup opacity values will be
-     *     returned for each temperature provided.  The opacity
-     *     container should have a length equal to the number of
-     *     temperatures times the number of energy groups for
-     *     multigroup data set.
-     *
-     * \param temperatureFirst The beginning position of a STL
-     *     container that holds a list of temperatures.
-     * \param temperatureLast The end position of a STL
-     *     container that holds a list of temperatures.
-     * \param targetDensity The single density value used when
-     *     computing opacities for each given temperature.
-     * \param opacityFirst The beginning position of a STL
-     *     container into which opacity values corresponding to the
-     *     given temperature values will be stored.
-     * \return A list (of type OpacityIterator) of opacities are
-     *     returned.  These opacities correspond to the temperature
-     *     provided in the STL container and the single density value.
-     */
+   * \brief Opacity accessor that utilizes STL-like iterators.  This accessor
+   *     expects a list of temperatures in an STL container.  A set of
+   *     multigroup opacity values will be returned for each temperature
+   *     provided.  The opacity container should have a length equal to the
+   *     number of temperatures times the number of energy groups for multigroup
+   *     data set.
+   *
+   * \param temperatureFirst The beginning position of a STL container that
+   *     holds a list of temperatures.
+   * \param temperatureLast The end position of a STL container that holds a
+   *     list of temperatures.
+   * \param targetDensity The single density value used when computing opacities
+   *     for each given temperature.
+   * \param opacityFirst The beginning position of a STL container into which
+   *     opacity values corresponding to the
+   *     given temperature values will be stored.
+   * \return A list (of type OpacityIterator) of opacities are returned.  These
+   *     opacities correspond to the temperature provided in the STL container
+   *     and the single density value.
+   */
   template <class TemperatureIterator, class OpacityIterator>
   OpacityIterator getOpacity(TemperatureIterator temperatureFirst,
                              TemperatureIterator temperatureLast,
@@ -269,150 +257,135 @@ public:
                              OpacityIterator opacityFirst) const;
 
   /*!
-     * \brief Opacity accessor that utilizes STL-like iterators.  This
-     *     accessor expects a list of densities in an STL
-     *     container.  A set of multigroup opacity values will be
-     *     returned for each density provided.  The opacity
-     *     container should have a length equal to the number of
-     *     density times the number of energy groups for
-     *     multigroup data set.
-     *
-     * \param targetTemperature The single temperature value used when
-     *     computing opacities for each given density.
-     * \param densityFirst The beginning position of a STL
-     *     container that holds a list of densities.
-     * \param densityLast The end position of a STL
-     *     container that holds a list of densities.
-     * \param opacityFirst The beginning position of a STL
-     *     container into which opacity values corresponding to the
-     *     given density values will be stored.
-     * \return A list (of type OpacityIterator) of opacities are
-     *     returned.  These opacities correspond to the density
-     *     provided in the STL container and the single temperature value.
-     */
+   * \brief Opacity accessor that utilizes STL-like iterators.  This accessor
+   *     expects a list of densities in an STL container.  A set of multigroup
+   *     opacity values will be returned for each density provided.  The opacity
+   *     container should have a length equal to the number of density times the
+   *     number of energy groups for multigroup data set.
+   *
+   * \param targetTemperature The single temperature value used when computing
+   *     opacities for each given density.
+   * \param densityFirst The beginning position of a STL container that holds a
+   *     list of densities.
+   * \param densityLast The end position of a STL container that holds a list of
+   *     densities.
+   * \param opacityFirst The beginning position of a STL container into which
+   *     opacity values corresponding to the given density values will be
+   *     stored.
+   * \return A list (of type OpacityIterator) of opacities are returned.  These
+   *     opacities correspond to the density provided in the STL container and
+   *     the single temperature value.
+   */
   template <class DensityIterator, class OpacityIterator>
   OpacityIterator
   getOpacity(double targetTemperature, DensityIterator densityFirst,
              DensityIterator densityLast, OpacityIterator opacityFirst) const;
 
   /*!
-     * \brief Opacity accessor that returns a
-     *     vector of opacities that
-     *     corresponds to the provided temperature and density.
-     *
-     * \param targetTemperature The temperature value for which an
-     *     opacity value is being requested.
-     * \param targetDensity The density value for which an opacity
-     *     value is being requested.
-     * \return A vector of opacities.
-     */
+   * \brief Opacity accessor that returns a vector of opacities that corresponds
+   *     to the provided temperature and density.
+   *
+   * \param targetTemperature The temperature value for which an opacity value
+   *     is being requested.
+   * \param targetDensity The density value for which an opacity value is being
+   *     requested.
+   * \return A vector of opacities.
+   */
   std::vector<double> getOpacity(double targetTemperature,
                                  double targetDensity) const;
 
   /*!
-     * \brief Opacity accessor that returns a vector of vectors of
-     *     opacities
-     *     that correspond to the provided vector of
-     *     temperatures and a single density value.
-     *
-     * \param targetTemperature A vector of temperature values for
-     *     which opacity values are being requested.
-     * \param targetDensity The density value for which an opacity
-     *     value is being requested.
-     * \return A vector of vectors of opacities.
-     */
+   * \brief Opacity accessor that returns a vector of vectors of opacities that
+   *     correspond to the provided vector of temperatures and a single density
+   *     value.
+   *
+   * \param targetTemperature A vector of temperature values for which opacity
+   *     values are being requested.
+   * \param targetDensity The density value for which an opacity value is being
+   *     requested.
+   * \return A vector of vectors of opacities.
+   */
   std::vector<std::vector<double>>
   getOpacity(std::vector<double> const &targetTemperature,
              double targetDensity) const;
 
   /*!
-     * \brief Opacity accessor that returns a vector of vectors of
-     *     opacities that correspond to the provided vector of
-     *     densities and a single temperature value.
-     *
-     * \param targetTemperature The temperature value for which an
-     *     opacity value is being requested.
-     * \param targetDensity A vector of density values for which
-     *     opacity values are being requested.
-     * \return A vector of vectors of opacities.
-     */
+   * \brief Opacity accessor that returns a vector of vectors of opacities that
+   *     correspond to the provided vector of densities and a single temperature
+   *     value.
+   *
+   * \param targetTemperature The temperature value for which an opacity value
+   *     is being requested.
+   * \param targetDensity A vector of density values for which opacity values
+   *     are being requested.
+   * \return A vector of vectors of opacities.
+   */
   std::vector<std::vector<double>>
   getOpacity(double targetTemperature,
              std::vector<double> const &targetDensity) const;
 
-  /*!
-     * \brief Query whether the data is in tables or functional form.
-     */
+  //! Query whether the data is in tables or functional form.
   bool data_in_tabular_form() const { return true; }
 
-  /*!
-     * \brief Query to determine the reaction model.
-     */
+  //! Query to determine the reaction model.
   rtt_cdi::Reaction getReactionType() const { return opacityReaction; }
 
-  /*!
-     * \brief Query to determine the physics model.
-     */
+  //! Query to determine the physics model.
   rtt_cdi::Model getModelType() const { return opacityModel; }
 
   /*!
-     * \brief Returns a string that describes the templated
-     *     EnergyPolicy.  Currently this will return either "mg" or
-     *     "gray."
-     */
+   * \brief Returns a string that describes the templated EnergyPolicy.
+   *     Currently this will return either "mg" or "gray."
+   */
   std::string getEnergyPolicyDescriptor() const {
     return energyPolicyDescriptor;
   };
 
   /*!
-     * \brief Returns a "plain English" description of the opacity
-     *     data that this class references. (e.g. "Multigroup Rosseland
-     *     Scattering".)
-     *
-     * The definition of this function is not included here to prevent
-     *     the inclusion of the IpcressFile.hh definitions within this
-     *     header file.
-     */
+   * \brief Returns a "plain English" description of the opacity data that this
+   *     class references. (e.g. "Multigroup Rosseland Scattering".)
+   *
+   *     The definition of this function is not included here to prevent the
+   *     inclusion of the IpcressFile.hh definitions within this header file.
+   */
   std::string getDataDescriptor() const {
     return spIpcressDataTable->getDataDescriptor();
   }
 
   /*!
-     * \brief Returns the name of the associated IPCRESS file.
-     *
-     * The definition of this function is not included here to prevent
-     *     the inclusion of the IpcressFile.hh definitions within this
-     *     header file.
-     */
+   * \brief Returns the name of the associated IPCRESS file.
+   *
+   *     The definition of this function is not included here to prevent the
+   *     inclusion of the IpcressFile.hh definitions within this header file.
+   */
   std::string getDataFilename() const { return ipcressFilename; }
 
   /*!
-     * \brief Returns a vector of temperatures that define the cached
-     *     opacity data table.
-     *
-     * We do not return a const reference because this function
-     * must construct this information from more fundamental tables.
-     */
+   * \brief Returns a vector of temperatures that define the cached opacity data
+   *     table.
+   *
+   *     We do not return a const reference because this function must construct
+   *     this information from more fundamental tables.
+   */
   std::vector<double> getTemperatureGrid() const {
     return spIpcressDataTable->getTemperatures();
   }
 
   /*!
-     * \brief Returns a vector of densities that define the cached
-     *     opacity data table.
-     *
-     * We do not return a const reference because this function
-     * must construct this information from more fundamental tables.
-     */
+   * \brief Returns a vector of densities that define the cached opacity data
+   *     table.
+   *
+   * We do not return a const reference because this function must construct
+   *     this information from more fundamental tables.
+   */
   std::vector<double> getDensityGrid() const {
     return spIpcressDataTable->getDensities();
   }
 
   /*!
-     * \brief Returns a vector of energy values (keV) that define the
-     *     energy boundaries of the cached multigroup opacity data
-     *     table.
-     */
+   * \brief Returns a vector of energy values (keV) that define the energy
+   *     boundaries of the cached multigroup opacity data table.
+   */
   std::vector<double> getGroupBoundaries() const {
     return spIpcressDataTable->getGroupBoundaries();
   }
@@ -428,31 +401,31 @@ public:
   }
 
   /*!
-     * \brief Returns the number of group boundaries found in the
-     *     current multigroup data set.
-     */
+   * \brief Returns the number of group boundaries found in the current
+   *     multigroup data set.
+   */
   size_t getNumGroupBoundaries() const {
     return spIpcressDataTable->getNumGroupBoundaries();
   }
 
   /*!
-     * \brief Returns the number of gruops found in the current
-     *     multigroup data set.
-     */
+   * \brief Returns the number of gruops found in the current multigroup data
+   *     set.
+   */
   size_t getNumGroups() const { return getNumGroupBoundaries() - 1; };
 
   /*!
-     * \brief Pack a IpcressMulitgroupOpacity object.
-     *
-     * \return packed state in a vector<char>
-     */
+   * \brief Pack a IpcressMulitgroupOpacity object.
+   *
+   * \return packed state in a vector<char>
+   */
   std::vector<char> pack() const;
 
   /*!
-     * \brief Returns the general opacity model type, defined in OpacityCommon.hh
-     *
-     * Since this is a Ipcress model, return 2 (rtt_cdi::IPCRESS_TYPE)
-     */
+   * \brief Returns the general opacity model type, defined in OpacityCommon.hh
+   *
+   * Since this is a Ipcress model, return 2 (rtt_cdi::IPCRESS_TYPE)
+   */
   rtt_cdi::OpacityModelType getOpacityModelType() const {
     return rtt_cdi::IPCRESS_TYPE;
   }


### PR DESCRIPTION
+ Instead of using the Draco logo image for Jayenne and Capsaicin autodoc pages, let each project set its own image.
+ Fix a small bug in the `pull_repository_xf.sh` script that prevented the Capsaicin repository from being mirrored to the red network.
+ Cosmetic-only cleanup in cdi_ipcress.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
