### PR TITLE
Add an Abstract_Class_Contexual_Parser that parallels Abstract_Class_…

### DIFF
--- a/src/parser/Abstract_Class_Contextual_Parser.hh
+++ b/src/parser/Abstract_Class_Contextual_Parser.hh
@@ -1,0 +1,74 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   parser/Abstract_Class_Contextual_Parser.hh
+ * \author Kent Budge
+ * \brief  Define class Abstract_Class_Contextual_Parser
+ * \note   Copyright (C) 2016 Los Alamos National Security, LLC.
+ *         All rights reserved.
+ */
+//---------------------------------------------------------------------------//
+// $Id$
+//---------------------------------------------------------------------------//
+
+#ifndef parser_Abstract_Class_Contextual_Parser_hh
+#define parser_Abstract_Class_Contextual_Parser_hh
+
+#include "Abstract_Class_Parser.hh"
+
+namespace rtt_parser {
+
+//===========================================================================//
+/*!
+ * \class Abstract_Class_Contextual_Parser
+ * \brief Template for parser that produces a class object.
+ *
+ * This class is almost identical to Abstract_Class_Parser, except that the
+ * Parse_Function typedef is to a function taking an additional context
+ * argument.
+ *
+ * Note that this class is used only as a namespace; it should never have any
+ * nonstatic members. We use a class rather than namespace because we can't
+ * templatize names of namespaces.
+ *
+ * See test/tstAbstract_Class_Contextual_Parser for an example of its use.
+ */
+//===========================================================================//
+template <typename Abstract_Class, Parse_Table &get_parse_table(),
+          SP<Abstract_Class> &get_parsed_object(), typename Context,
+          Context const &get_context()>
+class Abstract_Class_Contextual_Parser {
+public:
+  // TYPES
+
+  typedef SP<Abstract_Class> Parse_Function(Token_Stream &, Context const &);
+
+  // STATIC members
+
+  //! Register children of the abstract class
+  static void register_child(string const &keyword,
+                             Parse_Function *parse_function);
+
+  //! Check the class invariants
+  static bool check_static_class_invariants();
+
+private:
+  // IMPLEMENTATION
+
+  //! Parse the child type
+  static void parse_child_(Token_Stream &, int);
+
+  // DATA
+
+  //! Map of child keywords to child creation functions
+  static vector<Parse_Function *> map_;
+};
+
+#include "Abstract_Class_Contextual_Parser.i.hh"
+
+} // end namespace rtt_parser
+
+#endif // parser_Abstract_Class_Contextual_Parser_hh
+
+//---------------------------------------------------------------------------//
+// end of parser/Abstract_Class_Contextual_Parser.hh
+//---------------------------------------------------------------------------//

--- a/src/parser/Abstract_Class_Contextual_Parser.i.hh
+++ b/src/parser/Abstract_Class_Contextual_Parser.i.hh
@@ -1,9 +1,9 @@
 //----------------------------------*-C++-*----------------------------------//
 /*!
- * \file   utils/Abstract_Class_Parser.i.hh
+ * \file   Abstract_Class_Contextual_Parser.i.hh
  * \author Kent Budge
  * \date   Thu Jul 17 14:08:42 2008
- * \brief  Member definitions of class Abstract_Class_Parser
+ * \brief  Member definitions of class Abstract_Class_Contextual_Parser
  * \note   Copyright (C) 2016 Los Alamos National Security, LLC.
  *         All rights reserved
  */
@@ -11,27 +11,8 @@
 // $Id$
 //---------------------------------------------------------------------------//
 
-#ifndef utils_Abstract_Class_Parser_i_hh
-#define utils_Abstract_Class_Parser_i_hh
-
-//===========================================================================//
-/*!
- * \class c_string_vector
- * \brief Table of raw strings (C strings) that does not leak.
- *
- * This class exists to hold a table of pointers to raw strings, allocated by
- * strdup, that will be properly cleaned up (using free) at program termination
- * so as not to show a memory leak in memory debugging tools.
- */
-class DLL_PUBLIC_parser c_string_vector {
-public:
-  ~c_string_vector();
-  c_string_vector(void) : data(0) { /* empty */
-  }
-  vector<char *> data;
-};
-
-extern c_string_vector abstract_class_parser_keys;
+#ifndef utils_Abstract_Class_Contextual_Parser_i_hh
+#define utils_Abstract_Class_Contextual_Parser_i_hh
 
 //===========================================================================//
 /*
@@ -41,10 +22,13 @@ extern c_string_vector abstract_class_parser_keys;
  * Remember: typedef SP<Abstract_Class> Parse_Function(Token_Stream &);
  */
 template <typename Class, Parse_Table &get_parse_table(),
-          SP<Class> &get_parsed_object()>
-vector<typename Abstract_Class_Parser<Class, get_parse_table,
-                                      get_parsed_object>::Parse_Function *>
-    Abstract_Class_Parser<Class, get_parse_table, get_parsed_object>::map_;
+          SP<Class> &get_parsed_object(), typename Context,
+          Context const &get_context()>
+vector<typename Abstract_Class_Contextual_Parser<Class, get_parse_table,
+                                                 get_parsed_object, Context,
+                                                 get_context>::Parse_Function *>
+    Abstract_Class_Contextual_Parser<Class, get_parse_table, get_parsed_object,
+                                     Context, get_context>::map_;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -57,9 +41,12 @@ vector<typename Abstract_Class_Parser<Class, get_parse_table,
  * Token_Stream and returns a corresponding object of the child class.
  */
 template <typename Class, Parse_Table &get_parse_table(),
-          SP<Class> &get_parsed_object()>
-void Abstract_Class_Parser<Class, get_parse_table, get_parsed_object>::
-    register_child(string const &keyword, Parse_Function *parse_function) {
+          SP<Class> &get_parsed_object(), typename Context,
+          Context const &get_context()>
+void Abstract_Class_Contextual_Parser<
+    Class, get_parse_table, get_parsed_object, Context,
+    get_context>::register_child(string const &keyword,
+                                 Parse_Function *parse_function) {
   using namespace rtt_parser;
 
   char *cptr = new char[keyword.size() + 1];
@@ -83,30 +70,34 @@ void Abstract_Class_Parser<Class, get_parse_table, get_parsed_object>::
  * makes use of the Parse_Function associated with each child keyword.
  */
 template <typename Class, Parse_Table &get_parse_table(),
-          SP<Class> &get_parsed_object()>
-void Abstract_Class_Parser<Class, get_parse_table, get_parsed_object>::
-    parse_child_(Token_Stream &tokens, int const child) {
+          SP<Class> &get_parsed_object(), typename Context,
+          Context const &get_context()>
+void Abstract_Class_Contextual_Parser<
+    Class, get_parse_table, get_parsed_object, Context,
+    get_context>::parse_child_(Token_Stream &tokens, int const child) {
   Check(static_cast<unsigned>(child) < map_.size());
 
   if (get_parsed_object() != SP<Class>()) {
     tokens.report_semantic_error("specification already exists");
   }
 
-  get_parsed_object() = map_[child](tokens);
+  get_parsed_object() = map_[child](tokens, get_context());
 
   Ensure(check_static_class_invariants());
 }
 
 //---------------------------------------------------------------------------//
 template <typename Class, Parse_Table &get_parse_table(),
-          SP<Class> &get_parsed_object()>
-bool Abstract_Class_Parser<Class, get_parse_table,
-                           get_parsed_object>::check_static_class_invariants() {
+          SP<Class> &get_parsed_object(), typename Context,
+          Context const &get_context()>
+bool Abstract_Class_Contextual_Parser<
+    Class, get_parse_table, get_parsed_object, Context,
+    get_context>::check_static_class_invariants() {
   return true; // no significant invariant for now
 }
 
-#endif // utils_Abstract_Class_Parser_i_hh
+#endif // utils_Abstract_Class_Contextual_Parser_i_hh
 
 //---------------------------------------------------------------------------//
-// end of utils/Abstract_Class_Parser.i.hh
+// end of utils/Abstract_Class_Contextual_Parser.i.hh
 //---------------------------------------------------------------------------//

--- a/src/parser/Abstract_Class_Parser.cc
+++ b/src/parser/Abstract_Class_Parser.cc
@@ -14,11 +14,10 @@
 
 namespace rtt_parser {
 
-DLL_PUBLIC_parser Abstract_Class_Parser_Base::c_string_vector
-    Abstract_Class_Parser_Base::keys_;
+DLL_PUBLIC_parser c_string_vector abstract_class_parser_keys;
 
 //---------------------------------------------------------------------------//
-Abstract_Class_Parser_Base::c_string_vector::~c_string_vector() {
+c_string_vector::~c_string_vector() {
   unsigned const n = data.size();
   for (unsigned i = 0; i < n; ++i) {
     delete[] data[i];

--- a/src/parser/Abstract_Class_Parser.hh
+++ b/src/parser/Abstract_Class_Parser.hh
@@ -24,36 +24,6 @@ using rtt_dsxx::SP;
 
 //===========================================================================//
 /*!
- * \class Abstract_Class_Parser_Base
- * \brief Template for parser that produces a class object.
- *
- * This class exists only to serve as a base for Abstract_Class_Parser,
- * allowing all such parsers to share the same keyword table and ensuring that
- * the keyword table is properly cleaned up when the program terminates.
- */
-class DLL_PUBLIC_parser Abstract_Class_Parser_Base {
-protected:
-  // TYPES
-
-  class DLL_PUBLIC_parser c_string_vector {
-  public:
-    ~c_string_vector();
-    c_string_vector(void) : data(0) { /* empty */
-    }
-    vector<char *> data;
-  };
-
-  // provide a virtual destrcutor for the base class.
-  virtual ~Abstract_Class_Parser_Base(){/* empty */};
-
-  // DATA
-
-  //! Keywords
-  static c_string_vector keys_;
-};
-
-//===========================================================================//
-/*!
  * \class Abstract_Class_Parser
  * \brief Template for parser that produces a class object.
  *
@@ -87,6 +57,10 @@ protected:
  * is simply a repository for keyword-parser combinations that is typically
  * used by the Class_Parser for the abstract class.
  *
+ * Note that this class is used only as a namespace; it should never have any
+ * nonstatic members. We use a class rather than namespace because we can't
+ * templatize names of namespaces.
+ *
  * See test/tstAbstract_Class_Parser for an example of its use.
  *
  * This template has proven useful but does not provide a fully satisfactory
@@ -96,7 +70,7 @@ protected:
 //===========================================================================//
 template <typename Abstract_Class, Parse_Table &get_parse_table(),
           SP<Abstract_Class> &get_parsed_object()>
-class Abstract_Class_Parser : private Abstract_Class_Parser_Base {
+class Abstract_Class_Parser {
 public:
   // TYPES
 

--- a/src/parser/test/contextual_sons_and_daughters.inp
+++ b/src/parser/test/contextual_sons_and_daughters.inp
@@ -1,0 +1,5 @@
+// parent
+  son
+    snips and snails 1.0
+  end
+end

--- a/src/parser/test/tstAbstract_Class_Contextual_Parser.cc
+++ b/src/parser/test/tstAbstract_Class_Contextual_Parser.cc
@@ -1,0 +1,407 @@
+//----------------------------------*-C++-*----------------------------------//
+/*!
+ * \file   parser/test/tstAbstract_Class_Contextual_Parser.cc
+ * \author Kent G. Budge
+ * \date   Tue Nov  9 14:34:11 2010
+ * \brief  Test the Abstract_Class_Contextual_Parser template
+ * \note   Copyright (C) 2016 Los Alamos National Security, LLC.
+ *         All rights reserved.
+ */
+//---------------------------------------------------------------------------//
+// $Id$
+//---------------------------------------------------------------------------//
+
+#include "ds++/Release.hh"
+#include "ds++/ScalarUnitTest.hh"
+#include "parser/Abstract_Class_Contextual_Parser.hh"
+#include "parser/Class_Parse_Table.hh"
+#include "parser/File_Token_Stream.hh"
+#include "parser/utilities.hh"
+
+using namespace std;
+using namespace rtt_dsxx;
+using namespace rtt_parser;
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+/*
+ * Declare an abstract class, Parent, for which we wish to write a constructor.
+ * The following would typically be declared in a file named Parent.hh
+ */
+
+class Parent {
+public:
+  explicit Parent(int const magic) : magic_(magic) {}
+  // The argument is provided by the parser context and has a magic value, 42,
+  // if the parser has handled context correctly.
+
+  int magic() const { return magic_; }
+
+  virtual ~Parent() {}
+
+  virtual string name() = 0;
+  // Makes this class abstract, and gives us a way to test later which child
+  // has actually been parsed.
+
+private:
+  int magic_;
+};
+
+//---------------------------------------------------------------------------//
+/*
+ * Declare a parse table for parsing objects derived from Parent. Note that
+ * this must be in the rtt_parser namespace regardless of which namespace
+ * Parent lives in.
+ */
+namespace rtt_parser {
+
+template <> class Class_Parse_Table<Parent> {
+public:
+  // TYPEDEFS
+
+  typedef Parent Return_Class;
+
+  // MANAGEMENT
+
+  Class_Parse_Table(int const &context) : context(context) {
+    child_.reset();
+    // Should contain a pointer to a child of Parent after parsing is complete.
+    current_ = this;
+    // If there are any parsed parameters common to all children of Parent, they
+    // should be placed in Class_Parse_Table<Parent> along with the associated
+    // parsing routines, which will populate the parameters through the current_
+    // pointer. This is necessary becuase the parsing routines must be static
+    // functions. (At least until we get ambitious with closures.
+  }
+
+  // SERVICES
+
+  bool allow_exit() const { return false; }
+
+  void check_completeness(Token_Stream &tokens) {
+    if (!child_) {
+      tokens.report_semantic_error("no parent specified");
+    }
+  }
+
+  SP<Parent> create_object() { return child_; }
+
+  // STATICS
+
+  Parse_Table const &parse_table() const { return parse_table_; }
+
+  static void register_model(string const &keyword,
+                             SP<Parent> parse_function(Token_Stream &,
+                                                       int const &)) {
+    Abstract_Class_Contextual_Parser<
+        Parent, get_parse_table_, get_parsed_object_, int,
+        get_context_>::register_child(keyword, parse_function);
+    // This function allows downstream developers to add new daughter classes
+    // to the parser without having to modify upstream code.
+  }
+
+protected:
+  // DATA
+
+  // This is where any parameters shared by all children of Parent would be placed.
+
+  int context;
+  // This is the parser context.
+
+private:
+  // IMPLEMENTATION
+
+  static Parse_Table &get_parse_table_() { return parse_table_; }
+
+  static SP<Parent> &get_parsed_object_() { return child_; }
+
+  static int const &get_context_() { return current_->context; }
+
+  // DATA
+
+  static SP<Parent> child_;
+  static Class_Parse_Table *current_;
+  static Parse_Table parse_table_;
+};
+
+SP<Parent> Class_Parse_Table<Parent>::child_;
+Class_Parse_Table<Parent> *Class_Parse_Table<Parent>::current_;
+Parse_Table Class_Parse_Table<Parent>::parse_table_;
+
+//---------------------------------------------------------------------------//
+/*
+ * Specialization of the parse_class template function for T=Parent
+ */
+template <> SP<Parent> parse_class(Token_Stream &tokens, int const &context) {
+  return parse_class_from_table<Class_Parse_Table<Parent>>(tokens, context);
+}
+
+} // namespace rtt_parser
+
+//---------------------------------------------------------------------------//
+/*
+ * We now declare a child class derived from Parent.  The following would
+ * normally be placed in the file Son.hh
+ */
+class Son : public Parent {
+public:
+  virtual string name() { return "son"; }
+
+  Son(double /*snip_and_snails*/, int const context) : Parent(context) {}
+  // "snips and snails" is provided by the parser based on the parsed
+  // specification, while context is provided by the parser context provided
+  // by the client. Since this is a toy example, we don't actually use the
+  // parameter, but we do want to check that the context is got right.
+};
+
+//---------------------------------------------------------------------------//
+/*
+ * Now declare a parser class for parsing specifications for Son. Typically
+ * the child parser class will be derived from the parent parser class so
+ * that parse code for common parameters does not have to be duplicated.
+ */
+namespace rtt_parser {
+template <> class Class_Parse_Table<Son> : public Class_Parse_Table<Parent> {
+public:
+  // TYPEDEFS
+
+  typedef Son Return_Class;
+
+  // MANAGEMENT
+
+  explicit Class_Parse_Table(int const context)
+      : Class_Parse_Table<Parent>(context) {
+    if (!parse_table_is_initialized_) {
+      // The parser class must populate the parse_table_ with the keywords
+      // and parse functions needed to parse a specification. This is done once
+      // the first time any Class_Parse_Table<Son> object is constructed.
+
+      const Keyword keywords[] = {
+          {"snips and snails", parse_snips_and_snails, 0, ""},
+      };
+
+      const unsigned number_of_keywords = sizeof(keywords) / sizeof(Keyword);
+      parse_table_.add(keywords, number_of_keywords);
+
+      parse_table_is_initialized_ = true;
+    }
+
+    // Initialize the parameters about to be parsed, typical with sentinel
+    // values that indicate whether the parameter has been found in the
+    // parsed specification.
+    snips_and_snails = -1;
+
+    // Set the current_ pointer to this object so that the parse routines,
+    // which must be static, will know where to find the
+    // Class_Parse_Table<Son> object in which to store parsed parameters.
+    current_ = this;
+    // If the parser is meant to support reentrancy, then the old current_
+    // pointer needs to be saved somewhere (such as a stack) so it can
+    // be retrieved later.
+  }
+
+  // SERVICES
+
+  bool allow_exit() const { return false; }
+
+  Parse_Table const &parse_table() const { return parse_table_; }
+
+  void check_completeness(Token_Stream &tokens) {
+    if (snips_and_snails == -1) {
+      tokens.report_semantic_error("no snips and snails specified");
+    }
+  }
+
+  SP<Son> create_object() {
+    SP<Son> Result(new Son(snips_and_snails, context));
+    return Result;
+  }
+
+protected:
+  // Parameter to be parsed
+
+  double snips_and_snails;
+
+private:
+  // STATIC
+
+  static void parse_snips_and_snails(Token_Stream &tokens, int) {
+    if (current_->snips_and_snails >= 0.0) {
+      tokens.report_semantic_error("snips and snails already specified");
+    }
+
+    current_->snips_and_snails = parse_real(tokens);
+    if (current_->snips_and_snails < 0.0) {
+      tokens.report_semantic_error("snips and snails must not be "
+                                   "negative");
+      current_->snips_and_snails = 2;
+      // It's customary to set parameters that have an invalid value
+      // specified to some benign valid value.
+    }
+  }
+
+  static Class_Parse_Table *current_;
+  static Parse_Table parse_table_;
+  static bool parse_table_is_initialized_;
+};
+
+//---------------------------------------------------------------------------//
+Class_Parse_Table<Son> *Class_Parse_Table<Son>::current_;
+Parse_Table Class_Parse_Table<Son>::parse_table_;
+bool Class_Parse_Table<Son>::parse_table_is_initialized_ = false;
+
+//---------------------------------------------------------------------------//
+template <> SP<Son> parse_class<Son>(Token_Stream &tokens, int const &context) {
+  return parse_class_from_table<Class_Parse_Table<Son>>(tokens, context);
+}
+
+} // end namespace rtt_parser
+
+//---------------------------------------------------------------------------//
+/*
+ * Now define a second child of Parent, which we will (whimsically) call
+ * Daughter. The following would typicall be placed in the file Daughter.hh
+ */
+
+class Daughter : public Parent {
+public:
+  virtual string name() { return "daughter"; }
+
+  Daughter(double /*sugar_and_spice*/) : Parent(0) {}
+  // This child doesn't care about the context, which is perfectly acceptable
+  // (if it makes sense).
+};
+
+//---------------------------------------------------------------------------//
+/*
+ * Define a parser class now for Daughter. This is similar to what we do for
+ * Son so we will go light on comments.
+ */
+namespace rtt_parser {
+template <> class Class_Parse_Table<Daughter> {
+public:
+  // TYPEDEFS
+
+  typedef Daughter Return_Class;
+
+  // MANAGEMENT
+
+  Class_Parse_Table() {
+    if (!parse_table_is_initialized_) {
+      const Keyword keywords[] = {
+          {"sugar and spice", parse_sugar_and_spice, 0, ""},
+      };
+
+      const unsigned number_of_keywords = sizeof(keywords) / sizeof(Keyword);
+      parse_table_.add(keywords, number_of_keywords);
+      parse_table_is_initialized_ = true;
+    }
+
+    sugar_and_spice = -1;
+
+    current_ = this;
+  }
+
+  // SERVICES
+
+  bool allow_exit() const { return false; }
+
+  Parse_Table const &parse_table() const { return parse_table_; }
+
+  void check_completeness(Token_Stream &tokens) {
+    if (sugar_and_spice == -1) {
+      tokens.report_semantic_error("no sugar and spice specified");
+    }
+  }
+
+  SP<Daughter> create_object() {
+    SP<Daughter> Result(new Daughter(sugar_and_spice));
+    return Result;
+  }
+
+protected:
+  double sugar_and_spice;
+
+private:
+  // STATIC
+
+  static void parse_sugar_and_spice(Token_Stream &tokens, int) {
+    if (current_->sugar_and_spice >= 0.0) {
+      tokens.report_semantic_error("sugar and spice already specified");
+    }
+
+    current_->sugar_and_spice = parse_real(tokens);
+    if (current_->sugar_and_spice < 0.0) {
+      tokens.report_semantic_error("sugar and spice must not be "
+                                   "negative");
+      current_->sugar_and_spice = 2;
+    }
+  }
+
+  static Class_Parse_Table *current_;
+  static Parse_Table parse_table_;
+  static bool parse_table_is_initialized_;
+};
+
+Class_Parse_Table<Daughter> *Class_Parse_Table<Daughter>::current_;
+Parse_Table Class_Parse_Table<Daughter>::parse_table_;
+bool Class_Parse_Table<Daughter>::parse_table_is_initialized_;
+
+//---------------------------------------------------------------------------//
+template <> SP<Daughter> parse_class<Daughter>(Token_Stream &tokens) {
+  return parse_class_from_table<Class_Parse_Table<Daughter>>(tokens);
+}
+
+} // end namespace rtt_parser
+
+// The following are the kinds of parse functions that a downwind developer
+// might write for his own children of the Parent class.
+
+SP<Parent> parse_son(Token_Stream &tokens, int const &context) {
+  return parse_class<Son>(tokens, context);
+}
+
+SP<Parent> parse_daughter(Token_Stream &tokens, int const &) {
+  return parse_class<Daughter>(tokens);
+}
+
+//---------------------------------------------------------------------------//
+/* Test all the above */
+
+void test(UnitTest &ut) {
+  // Register the children parse functions with the Parent parse class.
+  Class_Parse_Table<Parent>::register_model("son", parse_son);
+  Class_Parse_Table<Parent>::register_model("daughter", parse_daughter);
+
+  // Build path for the input file containing a test specification for a Son.
+  string const sadInputFile(ut.getTestSourcePath() +
+                            std::string("contextual_sons_and_daughters.inp"));
+
+  File_Token_Stream tokens(sadInputFile);
+
+  SP<Parent> parent = parse_class<Parent>(tokens, 42);
+  // We choose 42 as the magic value for our context, in honor of hitchikers
+  // across the Galaxy.
+
+  cout << parent->name() << endl;
+
+  ut.check(tokens.error_count() == 0, "parsed without error");
+  ut.check(parent, "created parent", true);
+  ut.check(parent->name() == "son", "parent is son");
+  ut.check(parent->magic() == 42, "context");
+}
+
+//---------------------------------------------------------------------------//
+
+int main(int argc, char *argv[]) {
+  ScalarUnitTest ut(argc, argv, release);
+  try {
+    test(ut);
+  }
+  UT_EPILOG(ut);
+}
+
+//---------------------------------------------------------------------------//
+// end of tstAbstract_Class_Contextual_Parser.cc
+//---------------------------------------------------------------------------//


### PR DESCRIPTION
* The class Abstract_Class_Contextual_Parser is nearly identical to Abstract_Class_Parser; the only significant difference is that the Parse_Function typedef is to a function taking an additional context argument. Its use is documented in the test file test/tstAbstract_Class_Contextual_Parser.cc
* I noticed while writing this class that there was an uncovered destructor in Abstract_Class_Parser_Base. On further reflection, I realized that this class is much more machinery than is needed to perform its function, so I stripped it down to its core and moved this into Abstract_Class_Parser.i.hh.

* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
  * [ ] Test on Win32 and Sequoia. This PR touches routines that we had a lot of trouble compiling on non-Linux machines.
