### PR TITLE
Add new 'pause' command line option for ParallelUnitTest.

### DIFF
--- a/src/c4/ParallelUnitTest.cc
+++ b/src/c4/ParallelUnitTest.cc
@@ -5,10 +5,7 @@
  * \date   Thu Jun  1 17:15:05 2006
  * \brief  Implementation file for encapsulation of Draco parallel unit tests.
  * \note   Copyright (C) 2016 Los Alamos National Security, LLC.
- *         All rights reserved.
- */
-//---------------------------------------------------------------------------//
-// $Id$
+ *         All rights reserved. */
 //---------------------------------------------------------------------------//
 
 #include "ParallelUnitTest.hh"
@@ -60,14 +57,26 @@ ParallelUnitTest::ParallelUnitTest(int &argc, char **&argv,
 
   // Register and process command line arguments:
   rtt_dsxx::XGetopt::csmap long_options;
-  long_options['v'] = "version";
   std::map<char, std::string> help_strings;
+  long_options['v'] = "version";
   help_strings['v'] = "print version information and exit.";
+  long_options['p'] = "pause";
+  help_strings['p'] = "pause program at MPI init to allow debugger to attach";
   rtt_dsxx::XGetopt program_options(argc, argv, long_options, help_strings);
 
   int c(0);
   while ((c = program_options()) != -1) {
     switch (c) {
+    case 'p': // --pause
+      char chtmp;
+      if (rtt_c4::node() == 0) {
+        std::cout << "Program paused to allow debugger to attach.\n"
+                  << "Enter any single char to continue...";
+        std::cin >> chtmp;
+      }
+      rtt_c4::global_barrier();
+      break;
+
     case 'v': // --version
       finalize();
       throw rtt_dsxx::assertion(string("Success"));


### PR DESCRIPTION
+ Any unit test that is based on c4's ParallelUnitTest can now be given the command line argument '-p'.  This option will pause the program after MPI_Init to allow the developer to attach a debugger to the process before the program continues. This can be useful when debugging code on platforms that do not have a MPI-aware debugger.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass (small decrease in coverage due to difficulty in testing new interactive option)
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
