### PR TITLE
Restrict how many valgrind jobs are run simultaneously by regress

### DIFF
--- a/environment/bin/bash_functions.sh
+++ b/environment/bin/bash_functions.sh
@@ -73,6 +73,9 @@ function cleanemacs
 ## ...scratch...    -> #
 ## .../projects/... -> @
 ##---------------------------------------------------------------------------##
+parse_git_branch() {
+  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
+}
 
 function npwd()
 {

--- a/regression/draco_regression_macros.cmake
+++ b/regression/draco_regression_macros.cmake
@@ -721,11 +721,20 @@ covdir -o ${CTEST_BINARY_DIRECTORY}/covdir.log")
         "-q --tool=memcheck --leak-check=full --trace-children=yes --gen-suppressions=all ${valgrind_suppress_option}" )
     endif()
     message(" CTEST_MEMORYCHECK_COMMAND_OPTIONS = ${CTEST_MEMORYCHECK_COMMAND_OPTIONS}")
-    message( "ctest_memcheck( SCHEDULE_RANDOM ON
-                EXCLUDE_LABEL nomemcheck )")
-    ctest_memcheck(
-      SCHEDULE_RANDOM ON
-      EXCLUDE_LABEL "nomemcheck")
+
+    set( ctest_memcheck_options "SCHEDULE_RANDOM ON" )
+    string( APPEND ctest_memcheck_options " PARALLEL_LEVEL ${num_test_procs}" )
+    string( APPEND ctest_memcheck_options " EXCLUDE_LABEL nomemcheck ")
+
+    # if we are running on a machine that openly shares resources, use the
+    # TEST_LOAD feature to limit the number of cores used while testing. For
+    # machines that run schedulers, the whole allocation is available so there is
+    # no need to limit the load.
+    if( "${CTEST_SITE}" MATCHES "ccscs" )
+      string( APPEND ctest_memcheck_options " TEST_LOAD ${max_system_load}" )
+    endif()
+    message( "ctest_memcheck( ${ctest_memcheck_options} )" )
+    ctest_memcheck( ${ctest_memcheck_options} )
   endif()
 endmacro(process_cc_or_da)
 


### PR DESCRIPTION
+ This will reduce the load on ccscs7 when many PRs are being tested simultaneously.
+ Also sneak in a new bash function 'parse_git_branch'.  This allows developers to include the git branch name in their user command prompt for directories that contain a git repository.  For example:

```
export PS1="\[\033[34m\]\h:\[\033[32m\]\$(npwd)\[\033[35m\]\$(parse_git_branch)\[\033[00m\] [\!] % "

cd $HOME/draco
ccscs7:~/draco (regress-scripts) [1007] % 
```

* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [ ] Code reviewed/approved, sufficient DbC checks, testing, documentation
