### PR TITLE
Tweaks for Windows platforms (VS2017 and MSYS2).

### DIFF
--- a/config/application_unit_test.py
+++ b/config/application_unit_test.py
@@ -574,10 +574,14 @@ class UnitTest:
         clean_run_args.append(arg)
       if diff_exe.strip():
         clean_run_args.append(diff_exe.strip())
+        # If we are using fc on win32, assume that we want to compare binary 
+        # files.
+        if (diff_name == "fc"):
+          clean_run_args.append("/b")
       if path_1.strip():
-        clean_run_args.append(path_1.strip())
+        clean_run_args.append(os.path.abspath(path_1.strip()))
       if path_2.strip():
-        clean_run_args.append(path_2.strip())
+        clean_run_args.append(os.path.abspath(path_2.strip()))
       for arg in diff_args.split():
         if arg: clean_run_args.append(arg)
 

--- a/config/compilerEnv.cmake
+++ b/config/compilerEnv.cmake
@@ -40,9 +40,7 @@ endif()
 # ------------------------------------------------------------------------------
 site_name( SITENAME )
 string( REGEX REPLACE "([A-z0-9]+).*" "\\1" SITENAME ${SITENAME} )
-if( ${SITENAME} MATCHES "c[it]" )
-  set( SITENAME "Cielito" )
-elseif( ${SITENAME} MATCHES "ml" OR ${SITENAME} MATCHES "lu" )
+if( ${SITENAME} MATCHES "ml" OR ${SITENAME} MATCHES "lu" )
   set( SITENAME "Moonlight" )
 elseif( ${SITENAME} MATCHES "tt") #" -login[0-9]+" OR ${SITENAME} MATCHES "tt-fey[0-9]+" )
   set( SITENAME "Trinitite" )
@@ -94,8 +92,6 @@ macro(dbsSetupCompilers)
   # we use it. This value is used in component_macros.cmake when properties
   # are assigned to individual targets. Current status:
   #
-  # - Cielito/Cielo: Intel with IPO (-ipo flag and linking with xiar) causes
-  #   parser/tstutilities to fail.
   # - Moonlight/Luna: Intel with IPO (-ipo flag) causes
   #   wedgehog_components/tstCensus_Manger_DD_2 to fail.
   # In component_macros.cmake, this target property will be set:
@@ -332,8 +328,9 @@ macro(dbsSetupFortran)
     find_program( CAFS_Fortran_COMPILER
       NAMES ${CAFS_Fortran_COMPILER} $ENV{CAFS_Fortran_COMPILER} gfortran
       PATHS
-      c:/MinGW/bin
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\MinGW;InstallLocation]/bin" )
+        c:/MinGW/bin
+        c:/msys64/usr/bin
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\MinGW;InstallLocation]/bin" )
 
     if( EXISTS ${CAFS_Fortran_COMPILER} )
       set( HAVE_Fortran ON )

--- a/config/component_macros.cmake
+++ b/config/component_macros.cmake
@@ -330,9 +330,8 @@ macro( add_component_library )
   # Find target file name and location
   get_target_property( impname ${acl_TARGET} OUTPUT_NAME )
 
-  # the above command returns the location in the build tree.  We
-  # need to convert this to the install location.
-  # get_filename_component( imploc ${imploc} NAME )
+  # the above command returns the location in the build tree.  We need to 
+  # convert this to the install location.
   if( ${DRACO_SHARED_LIBS} )
     set( imploc "${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}${impname}${CMAKE_SHARED_LIBRARY_SUFFIX}" )
   else()
@@ -340,7 +339,7 @@ macro( add_component_library )
   endif()
 
   set( ilil "")
-  if( "${acl_TARGET_DEPS}x" STREQUAL "x" AND  "${acl_VENDOR_LIBS}x" STREQUAL "x")
+  if( "${acl_TARGET_DEPS}x" STREQUAL "x" AND "${acl_VENDOR_LIBS}x" STREQUAL "x")
     # do nothing
   elseif( "${acl_TARGET_DEPS}x" STREQUAL "x" )
     set( ilil "${acl_VENDOR_LIBS}" )

--- a/config/windows-cl.cmake
+++ b/config/windows-cl.cmake
@@ -107,12 +107,14 @@ endif()
 # Extra runtime libraries...
 #
 
-find_library( Lib_win_winsock
-  NAMES wsock32;winsock32;ws2_32
-  HINTS
-  "C:/Program Files (x86)/Microsoft SDKs/Windows/v7.0A/Lib"
-  "C:/Windows/SysWOW64"
-  )
+find_library( Lib_win_winsock NAMES wsock32;winsock32;ws2_32 )
+if( EXISTS "${Lib_win_winsock}" AND CMAKE_CL_64 )
+  string(REPLACE "um/x86" "um/x64" Lib_win64_winsock "${Lib_win_winsock}" )
+  if( EXISTS "${Lib_win64_winsock}" )
+    set( Lib_win_winsock "${Lib_win64_winsock}")
+  endif()
+endif()
+
 if( ${Lib_win_winsock} MATCHES "NOTFOUND" )
   message( FATAL_ERROR "Could not find library winsock32 or ws2_32!" )
 endif()

--- a/src/viz/test/tstEnsight_Translator.py
+++ b/src/viz/test/tstEnsight_Translator.py
@@ -7,11 +7,10 @@
 # note   Copyright (C) 2016, Los Alamos National Security, LLC.
 #        All rights reserved.
 #------------------------------------------------------------------------------#
-# $Id: CMakeLists.txt 6721 2012-08-30 20:38:59Z gaber $
-#------------------------------------------------------------------------------#
 
 import sys
 import re
+import platform
 
 try:
 
@@ -54,19 +53,23 @@ try:
 
   # diff binary files if on little endian system
   if tEnsight_Translator.is_little_endian():
+    if any(platform.win32_ver()):
+      diff_prog="fc"
+    else: 
+      diff_prog="diff"
     print("\nSystem is little endian, diffing binary files\n")
     for var in vars:
       # testproblem_binary_ensight directory
       tEnsight_Translator.diff_two_files( "PROJECT_BINARY_DIR", \
         "testproblem_binary_ensight/{0}/data.0001".format(var), \
         "PROJECT_SOURCE_DIR", "bench/{0}.bin.0001".format(var), \
-        diff_name="diff")
+        diff_name="{0}".format(diff_prog))
 
       # part_testproblem_binary_ensight directory
       tEnsight_Translator.diff_two_files("PROJECT_BINARY_DIR", \
         "part_testproblem_binary_ensight/{0}/data.0001".format(var), \
         "PROJECT_SOURCE_DIR", "bench/{0}.bin.0001".format(var), \
-        diff_name="diff")
+        diff_name="{0}".format(diff_prog))
 
   ##--------------------------------------------------------------------------##
   ## Final report

--- a/src/viz/test/tstEnsight_Translator.py
+++ b/src/viz/test/tstEnsight_Translator.py
@@ -55,7 +55,7 @@ try:
   if tEnsight_Translator.is_little_endian():
     if any(platform.win32_ver()):
       diff_prog="fc"
-    else: 
+    else:
       diff_prog="diff"
     print("\nSystem is little endian, diffing binary files\n")
     for var in vars:
@@ -63,13 +63,13 @@ try:
       tEnsight_Translator.diff_two_files( "PROJECT_BINARY_DIR", \
         "testproblem_binary_ensight/{0}/data.0001".format(var), \
         "PROJECT_SOURCE_DIR", "bench/{0}.bin.0001".format(var), \
-        diff_name="{0}".format(diff_prog))
+        diff_name=diff_prog)
 
       # part_testproblem_binary_ensight directory
       tEnsight_Translator.diff_two_files("PROJECT_BINARY_DIR", \
         "part_testproblem_binary_ensight/{0}/data.0001".format(var), \
         "PROJECT_SOURCE_DIR", "bench/{0}.bin.0001".format(var), \
-        diff_name="{0}".format(diff_prog))
+        diff_name=diff_prog)
 
   ##--------------------------------------------------------------------------##
   ## Final report

--- a/src/viz/test/tstViz_Traits.cc
+++ b/src/viz/test/tstViz_Traits.cc
@@ -77,7 +77,7 @@ template <typename T> void test_FT(rtt_dsxx::UnitTest &ut) {
   for (size_t i = 0; i < field.size(); i++) {
     field[i].resize(i + 2);
     for (size_t j = 0; j < field[i].size(); j++)
-      field[i][j] = 2 * i + 4 * j;
+      field[i][j] = static_cast<T>(2 * i + 4 * j);
   }
 
   Test_Field<T> test_field(field);


### PR DESCRIPTION
+ On Windows platforms, if `diff` is not available use `fc`.
+ Remove another reference to Cielito and Cielo.
+ Teach the build system to find the 64-bit version of winsock.dll when building 64-bit targets.
+ Explicitly cast data types.
* [Pre-Merge Code Review](https://github.com/losalamos/Draco/wiki/Style-Guide)
  * [x] Travis CI checks pass
  * [x] Code coverage does not decrease
  * [x] [Valgrind test passes](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Toss2 checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] [Trinitite checks pass](https://rtt.lanl.gov/CDash/index.php?project=Draco)
  * [x] Code reviewed/approved, sufficient DbC checks, testing, documentation
  * [x] Win32 checks pass
